### PR TITLE
basic demo for macro

### DIFF
--- a/example/calcit.cirru
+++ b/example/calcit.cirru
@@ -47,6 +47,7 @@
                     :id |2OSM3qAy-k
                   |D $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600227583382) (:text |echo) (:id |RMNePIGCCb)
                   |L $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600227592094) (:text "|\"fibo result:") (:id |9nc7qp4Mg)
+                  |5 $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600532013007) (:text |;) (:id |MG-NuXHdw0)
                 :id |Ti5Ut3cxQf
               |yT $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1600138623767)
                 :data $ {}
@@ -70,6 +71,31 @@
                   |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1598199472456) (:text |println) (:id |VMIjBX-_Mrleaf)
                   |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1599547914240) (:text "|\"Loaded program!") (:id |9YM-sSKw_-)
                 :id |VMIjBX-_Mr
+              |yx $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1600532020250)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600532020870) (:text |eval) (:id |-CcgUbuxYleaf)
+                  |j $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1600532432977)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1600532021514)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600532021831) (:text |+) (:id |pTyV_EpGf)
+                          |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600532022749) (:text |1) (:id |qt3LH6Tr23)
+                          |r $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600532023629) (:text |2) (:id |Yazu4n--n5)
+                        :id |oagCHJFK0W
+                      |D $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600532434924) (:text |println) (:id |N7BqurRAk)
+                    :id |wpAUHETcmf
+                :id |-CcgUbuxY
+              |yyT $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1600533414664)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600533415947) (:text |println) (:id |tIPXtmHKyyleaf)
+                  |j $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1600533417485)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600533419374) (:text |gen-num) (:id |YOU5IlXBs_)
+                      |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600533422761) (:text |3) (:id |J9KsYYmQ_)
+                      |r $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600533423062) (:text |4) (:id |zneZfvixib)
+                      |v $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600533586759) (:text |c) (:id |z0YeAhFmne)
+                    :id |YiWnoFIY4B
+                :id |tIPXtmHKyy
               |r $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1598199469694) (:data $ {}) (:id |_AlBVa6VvM)
               |y $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1600138616749)
                 :data $ {}
@@ -83,6 +109,20 @@
                   |r $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600413852785) (:text "|\"2") (:id |pJnmtCU7FD)
                   |v $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600413852785) (:text |true) (:id |uhOc0hP2gQ)
                 :id |fn-MSSSN9w
+              |yy $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1600532717629)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600532719033) (:text |println) (:id |Rt-BnFGuADleaf)
+                  |j $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1600532719770)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600532723280) (:text |quote) (:id |b-vRWBfto)
+                      |j $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1600532723590)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600532723892) (:text |+) (:id |YR9gyTiYIM)
+                          |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600532724193) (:text |1) (:id |mQ5UvVVZay)
+                          |r $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600532724472) (:text |2) (:id |sMgg7Db8mD)
+                        :id |bMMcAsKB3x
+                    :id |ssGn5vqK5l
+                :id |Rt-BnFGuAD
               |yv $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1600409068518)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600409070765) (:text |+) (:id |z2XBPujUcleaf)
@@ -218,6 +258,35 @@
                     :id |qIM0pObt2h
                 :id |Jbezqio_x
             :id |0A4KuNL9BY
+          |gen-num $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1600533388568)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600533391697) (:text |defmacro) (:id |aal73DSfVj)
+              |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600533388568) (:text |gen-num) (:id |K6HyQepACb)
+              |r $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1600533388568)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600533394342) (:text |a) (:id |Ywkik0NDFm)
+                  |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600533395276) (:text |b) (:id |UdrB7p8oRm)
+                  |r $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600533600015) (:text |c) (:id |bWwED7vb2D)
+                :id |ef6ZyQGOmV
+              |v $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1600533396319)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600533397427) (:text |echo) (:id |zm7ziicB3Aleaf)
+                  |r $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600533398655) (:text |b) (:id |VW3tR01eOw)
+                  |f $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600533582067) (:text |a) (:id |fWJ1KWA7Z)
+                  |v $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600533601010) (:text |c) (:id |u2GZjYjYmU)
+                :id |zm7ziicB3A
+              |x $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1600533400445)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600533404167) (:text |quote) (:id |sU3smNj6mleaf)
+                  |j $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1600533407965)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600533408447) (:text |+) (:id |1kftLW08r)
+                      |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600533409568) (:text |1) (:id |9Avaj6nZv)
+                      |r $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600533409932) (:text |2) (:id |lVlmbLhUxQ)
+                      |v $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600533410307) (:text |3) (:id |ljqL15frZ)
+                    :id |ccsv9owdaF
+                :id |sU3smNj6m
+            :id |29atUO0etB
         :proc $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1596344532593) (:data $ {}) (:id |dXfpexltWn)
         :configs $ {} (:extension nil)
       |app.lib $ {}

--- a/example/compact.cirru
+++ b/example/compact.cirru
@@ -7,7 +7,10 @@
         ns app.main $ :require ([] app.lib :refer $ [] show-info) ([] app.lib :as lib)
       :defs $ {}
         |main! $ quote
-          defn main! () (println "\"Loaded program!") (echo "\"Running demo" $ demo 1 4) (show-info 1) (lib/show-info 2) (pr-str 1 "\"2" true) (echo "\"fibo result:" $ fibo 16) (+ 1 2)
+          defn main! () (println "\"Loaded program!") (echo "\"Running demo" $ demo 1 4) (show-info 1) (lib/show-info 2) (pr-str 1 "\"2" true) (; echo "\"fibo result:" $ fibo 16) (+ 1 2)
+            eval $ println (+ 1 2)
+            println $ quote (+ 1 2)
+            println $ gen-num 3 4 c
         |demo $ quote
           defn demo (x y) (echo "\"adding:" x y "\"result is" $ + x y)
         |reload! $ quote
@@ -22,6 +25,8 @@
           defn fibo (x)
             if (< x 2) (, 1)
               + (fibo $ - x 1) (fibo $ - x 2)
+        |gen-num $ quote
+          defmacro gen-num (a b c) (echo a b c) (quote $ + 1 2 3)
       :proc $ quote ()
       :configs $ {} (:extension nil)
     |app.lib $ {}

--- a/src/calcitRunner/data.nim
+++ b/src/calcitRunner/data.nim
@@ -3,6 +3,7 @@ import hashes
 import sets
 import options
 import system
+import terminal
 
 import cirruParser
 
@@ -40,6 +41,10 @@ proc hash*(value: CirruData): Hash =
     of crDataFn:
       result = hash("fn:")
       result = result !& hash(value.fnVal)
+      result = !$ result
+    of crDataMacro:
+      result = hash("macro:")
+      result = result !& hash(value.macroVal)
       result = !$ result
     of crDataVector:
       result = hash("vector:")
@@ -86,6 +91,8 @@ proc `==`*(x, y: CirruData): bool =
       return x.keywordVal == y.keywordVal
     of crDataFn:
       return x.fnVal == y.fnVal
+    of crDataMacro:
+      return x.macroVal == y.macroVal
 
     of crDataVector:
       if x.vectorVal.len != y.vectorVal.len:
@@ -238,6 +245,9 @@ proc toJson*(x: CirruData): JsonNode =
   of crDataFn:
     return JsonNode(kind: JNull)
 
+  of crDataMacro:
+    return JsonNode(kind: JNull)
+
   of crDataSymbol:
     return JsonNode(kind: JString, str: x.symbolVal)
 
@@ -289,6 +299,7 @@ proc len*(xs: CirruData): int =
   of crDataNil:
     return 0
   else:
+    coloredEcho(fgRed, $xs)
     raiseEvalError("Data has no len function", xs)
 
 proc isListData*(xs: CirruData): bool =

--- a/src/calcitRunner/format.nim
+++ b/src/calcitRunner/format.nim
@@ -46,6 +46,7 @@ proc toString*(val: CirruData): string =
     of crDataNil: "nil"
     of crDataKeyword: ":" & val.keywordVal
     of crDataFn: "::fn"
+    of crDataMacro: "::macro"
     of crDataSymbol: val.ns & "/" & val.symbolVal
 
 proc `$`*(v: CirruData): string =

--- a/src/calcitRunner/operations.nim
+++ b/src/calcitRunner/operations.nim
@@ -11,19 +11,19 @@ import ./data
 import ./types
 import ./helpers
 
-proc evalAdd*(exprList: CirruData, interpret: EdnEvalFn, ns: string, scope: CirruDataScope): CirruData =
+proc evalAdd*(exprList: CirruData, interpret: EdnEvalFn, scope: CirruDataScope): CirruData =
   if notListData(exprList):
     raiseEvalError(fmt"Expected cirru expr", exprList)
   var ret = 0.0
   for node in exprList[1..^1]:
-    let v = interpret(node, ns, scope)
+    let v = interpret(node, scope)
     if v.kind == crDataNumber:
       ret += v.numberVal
     else:
       raiseEvalError(fmt"Not a number {v.kind}", node)
   return CirruData(kind: crDataNumber, numberVal: ret)
 
-proc evalCompare*(exprList: CirruData, interpret: EdnEvalFn, ns: string, scope: CirruDataScope): CirruData =
+proc evalCompare*(exprList: CirruData, interpret: EdnEvalFn, scope: CirruDataScope): CirruData =
   if notListData(exprList):
     raiseEvalError(fmt"Expected cirru expr", exprList)
   if exprList.len < 3:
@@ -48,10 +48,10 @@ proc evalCompare*(exprList: CirruData, interpret: EdnEvalFn, ns: string, scope: 
   for idx, node in body:
     if idx >= (exprList.len - 2):
       break
-    let v = interpret(node, ns, scope)
+    let v = interpret(node, scope)
     if v.kind != crDataNumber:
       raiseEvalError(fmt"Not a number {v.kind}", node)
-    let vNext = interpret(body[idx + 1], ns, scope)
+    let vNext = interpret(body[idx + 1], scope)
     if vNext.kind != crDataNumber:
       raiseEvalError(fmt"Not a number {v.kind}", body[idx + 1])
     if not comparator(v.numberVal, vNext.numberVal):
@@ -59,43 +59,43 @@ proc evalCompare*(exprList: CirruData, interpret: EdnEvalFn, ns: string, scope: 
 
   return CirruData(kind: crDataBool, boolVal: true)
 
-proc evalMinus*(exprList: CirruData, interpret: EdnEvalFn, ns: string, scope: CirruDataScope): CirruData =
+proc evalMinus*(exprList: CirruData, interpret: EdnEvalFn, scope: CirruDataScope): CirruData =
   if notListData(exprList):
     raiseEvalError(fmt"Expected cirru expr", exprList)
   if (exprList.len == 1):
     return CirruData(kind: crDataNumber, numberVal: 0)
   elif (exprList.len == 2):
     let node = exprList[1]
-    let ret = interpret(node, ns, scope)
+    let ret = interpret(node, scope)
     if ret.kind == crDataNumber:
       return ret
     else:
       raiseInterpretException(fmt"Not a number {ret.kind}", node.line, node.column)
   else:
     let node = exprList[1]
-    let x0 = interpret(node, ns, scope)
+    let x0 = interpret(node, scope)
     var ret: float = 0
     if x0.kind == crDataNumber:
       ret = x0.numberVal
     else:
       raiseInterpretException(fmt"Not a number {x0.kind}", node.line, node.column)
     for node in exprList[2..^1]:
-      let v = interpret(node, ns, scope)
+      let v = interpret(node, scope)
       if v.kind == crDataNumber:
         ret -= v.numberVal
       else:
         raiseInterpretException(fmt"Not a number {v.kind}", node.line, node.column)
     return CirruData(kind: crDataNumber, numberVal: ret)
 
-proc evalArray*(exprList: CirruData, interpret: EdnEvalFn, ns: string, scope: CirruDataScope): CirruData =
+proc evalArray*(exprList: CirruData, interpret: EdnEvalFn, scope: CirruDataScope): CirruData =
   if notListData(exprList):
     raiseEvalError(fmt"Expected cirru expr", exprList)
   var arrayData: seq[CirruData]
   for child in exprList[1..^1]:
-    arrayData.add(interpret(child, ns, scope))
+    arrayData.add(interpret(child, scope))
   return CirruData(kind: crDataVector, vectorVal: arrayData)
 
-proc evalIf*(exprList: CirruData, interpret: EdnEvalFn, ns: string, scope: CirruDataScope): CirruData =
+proc evalIf*(exprList: CirruData, interpret: EdnEvalFn, scope: CirruDataScope): CirruData =
   if notListData(exprList):
     raiseEvalError(fmt"Expected cirru expr", exprList)
   if (exprList.len == 1):
@@ -106,36 +106,36 @@ proc evalIf*(exprList: CirruData, interpret: EdnEvalFn, ns: string, scope: Cirru
     raiseInterpretException("No arguments for if", node.line, node.column)
   elif (exprList.len == 3):
     let node = exprList[1]
-    let cond = interpret(node, ns, scope)
+    let cond = interpret(node, scope)
     if cond.kind == crDataBool:
       if cond.boolVal:
-        return interpret(exprList[2], ns, scope)
+        return interpret(exprList[2], scope)
       else:
         return CirruData(kind: crDataNil)
     else:
       raiseInterpretException("Not a bool in if", node.line, node.column)
   elif (exprList.len == 4):
     let node = exprList[1]
-    let cond = interpret(node, ns, scope)
+    let cond = interpret(node, scope)
     if cond.kind == crDataBool:
       if cond.boolVal:
-        return interpret(exprList[2], ns, scope)
+        return interpret(exprList[2], scope)
       else:
-        return interpret(exprList[3], ns, scope)
+        return interpret(exprList[3], scope)
     else:
       raiseInterpretException("Not a bool in if", node.line, node.column)
   else:
     let node = exprList[0]
     raiseInterpretException("Too many arguments for if", node.line, node.column)
 
-proc evalReadFile*(exprList: CirruData, interpret: EdnEvalFn, ns: string, scope: CirruDataScope): CirruData =
+proc evalReadFile*(exprList: CirruData, interpret: EdnEvalFn, scope: CirruDataScope): CirruData =
   raiseEvalError(fmt"Expected cirru expr", exprList)
   if exprList.len == 1:
     let node = exprList[0]
     raiseInterpretException("Lack of file name", node.line, node.column)
   elif exprList.len == 2:
     let node = exprList[1]
-    let fileName = interpret(node, ns, scope)
+    let fileName = interpret(node, scope)
     if fileName.kind == crDataSymbol:
       let content = readFile(fileName.symbolVal)
       return CirruData(kind: crDataString, stringVal: content)
@@ -145,7 +145,7 @@ proc evalReadFile*(exprList: CirruData, interpret: EdnEvalFn, ns: string, scope:
     let node = exprList[2]
     raiseInterpretException("Too many arguments!", node.line, node.column)
 
-proc evalWriteFile*(exprList: CirruData, interpret: EdnEvalFn, ns: string, scope: CirruDataScope): CirruData =
+proc evalWriteFile*(exprList: CirruData, interpret: EdnEvalFn, scope: CirruDataScope): CirruData =
   if notListData(exprList):
     raiseEvalError(fmt"Expected cirru expr", exprList)
   if exprList.len < 3:
@@ -153,11 +153,11 @@ proc evalWriteFile*(exprList: CirruData, interpret: EdnEvalFn, ns: string, scope
     raiseInterpretException("Lack of file name or target", node.line, node.column)
   elif exprList.len == 3:
     let node = exprList[1]
-    let fileName = interpret(node, ns, scope)
+    let fileName = interpret(node, scope)
     if fileName.kind != crDataSymbol:
       raiseInterpretException("Expected path name in string", node.line, node.column)
     let contentNode = exprList[2]
-    let content = interpret(contentNode, ns, scope)
+    let content = interpret(contentNode, scope)
     if content.kind != crDataSymbol:
       raiseInterpretException("Expected content in string", contentNode.line, contentNode.column)
     writeFile(fileName.symbolVal, content.symbolVal)
@@ -171,7 +171,7 @@ proc evalWriteFile*(exprList: CirruData, interpret: EdnEvalFn, ns: string, scope
 proc evalComment*(): CirruData =
   return CirruData(kind: crDataNil)
 
-proc evalArraySlice(value: seq[CirruData], exprList: CirruData, interpret: EdnEvalFn, ns: string, scope: CirruDataScope): CirruData =
+proc evalArraySlice(value: seq[CirruData], exprList: CirruData, interpret: EdnEvalFn, scope: CirruDataScope): CirruData =
   if notListData(exprList):
     raiseEvalError(fmt"Expected cirru expr", exprList)
   if exprList.len == 2:
@@ -180,7 +180,7 @@ proc evalArraySlice(value: seq[CirruData], exprList: CirruData, interpret: EdnEv
   if exprList.len > 4:
     let node = exprList[4]
     raiseEvalError("Too many arguments for Array slice", node)
-  let fromIdx = interpret(exprList[2], ns, scope)
+  let fromIdx = interpret(exprList[2], scope)
   if fromIdx.kind != crDataNumber:
     raiseEvalError("Not a number of from index", exprList[2])
 
@@ -192,7 +192,7 @@ proc evalArraySlice(value: seq[CirruData], exprList: CirruData, interpret: EdnEv
   if exprList.len == 3:
     return CirruData(kind: crDataVector, vectorVal: value[fromIdx.numberVal..^1])
 
-  let toIdx = interpret(exprList[3], ns, scope)
+  let toIdx = interpret(exprList[3], scope)
   if toIdx.kind != crDataNumber:
     raiseEvalError("Not a number of to index", exprList[3])
   if toIdx.numberVal < fromIdx.numberVal:
@@ -202,14 +202,14 @@ proc evalArraySlice(value: seq[CirruData], exprList: CirruData, interpret: EdnEv
 
   return CirruData(kind: crDataVector, vectorVal: value[fromIdx.numberVal..toIdx.numberVal])
 
-proc evalArrayConcat(value: seq[CirruData], exprList: CirruData, interpret: EdnEvalFn, ns: string, scope: CirruDataScope): CirruData =
+proc evalArrayConcat(value: seq[CirruData], exprList: CirruData, interpret: EdnEvalFn, scope: CirruDataScope): CirruData =
   if notListData(exprList):
     raiseEvalError(fmt"Expected cirru expr", exprList)
   if exprList.len < 2:
     raiseEvalError("Too few arguments", exprList[1])
   var arr: seq[CirruData]
   for idx, child in exprList[2..^1]:
-    let item = interpret(child, ns, scope)
+    let item = interpret(child, scope)
     if item.kind != crDataVector:
       raiseEvalError("Not an array in concat", exprList[idx + 2])
     for valueItem in item.vectorVal:
@@ -217,7 +217,7 @@ proc evalArrayConcat(value: seq[CirruData], exprList: CirruData, interpret: EdnE
 
   return CirruData(kind: crDataVector, vectorVal: arr)
 
-proc callArrayMethod*(value: var seq[CirruData], exprList: CirruData, interpret: EdnEvalFn, ns: string, scope: CirruDataScope): CirruData =
+proc callArrayMethod*(value: var seq[CirruData], exprList: CirruData, interpret: EdnEvalFn, scope: CirruDataScope): CirruData =
   if notListData(exprList):
     raiseEvalError(fmt"Expected cirru expr", exprList)
   if exprList.len < 2:
@@ -227,19 +227,19 @@ proc callArrayMethod*(value: var seq[CirruData], exprList: CirruData, interpret:
   case exprList[1].symbolVal
   of "add":
     for child in exprList[2..^1]:
-      let item = interpret(child, ns, scope)
+      let item = interpret(child, scope)
       value.add item
     return CirruData(kind: crDataVector, vectorVal: value)
   of "slice":
-    return evalArraySlice(value, exprList, interpret, ns, scope)
+    return evalArraySlice(value, exprList, interpret, scope)
   of "concat":
-    return evalArrayConcat(value, exprList, interpret, ns, scope)
+    return evalArrayConcat(value, exprList, interpret, scope)
   of "len":
     return CirruData(kind: crDataNumber, numberVal: value.len().float)
   else:
     raiseEvalError("Unknown method" & exprList[1].symbolVal, exprList[1])
 
-proc evalTable*(exprList: CirruData, interpret: EdnEvalFn, ns: string, scope: CirruDataScope): CirruData =
+proc evalTable*(exprList: CirruData, interpret: EdnEvalFn, scope: CirruDataScope): CirruData =
   if notListData(exprList):
     raiseEvalError(fmt"Expected cirru expr", exprList)
   var value = initTable[CirruData, CirruData]()
@@ -248,13 +248,13 @@ proc evalTable*(exprList: CirruData, interpret: EdnEvalFn, ns: string, scope: Ci
       raiseEvalError("Table requires nested children pairs", pair)
     if pair.len() != 2:
       raiseEvalError("Each pair of table contains 2 elements", pair)
-    let k = interpret(pair[0], ns, scope)
-    let v = interpret(pair[1], ns, scope)
+    let k = interpret(pair[0], scope)
+    let v = interpret(pair[1], scope)
     # TODO, import hash for CirruData
     # value.add(k, v)
   return CirruData(kind: crDataMap, mapVal: value)
 
-proc callTableMethod*(value: var Table[CirruData, CirruData], exprList: CirruData, interpret: EdnEvalFn, ns: string, scope: CirruDataScope): CirruData =
+proc callTableMethod*(value: var Table[CirruData, CirruData], exprList: CirruData, interpret: EdnEvalFn, scope: CirruDataScope): CirruData =
   if notListData(exprList):
     raiseEvalError(fmt"Expected cirru expr", exprList)
   if exprList.len < 2:
@@ -265,21 +265,21 @@ proc callTableMethod*(value: var Table[CirruData, CirruData], exprList: CirruDat
   of "get":
     if exprList.len != 3:
       raiseEvalError("Get method expects 1 argument", exprList[1])
-    let k = interpret(exprList[2], ns, scope)
+    let k = interpret(exprList[2], scope)
     return value[k]
 
   of "add":
     if exprList.len != 4:
       raiseEvalError("Add method expects 2 arguments", exprList[1])
-    let k = interpret(exprList[2], ns, scope)
-    let v = interpret(exprList[3], ns, scope)
+    let k = interpret(exprList[2], scope)
+    let v = interpret(exprList[3], scope)
     # value.add(k, v)
     return CirruData(kind: crDataMap, mapVal: value)
 
   of "del":
     if exprList.len != 3:
       raiseEvalError("Del method expects 1 argument", exprList[1])
-    let k = interpret(exprList[2], ns, scope)
+    let k = interpret(exprList[2], scope)
     value.del(k)
     return CirruData(kind: crDataMap, mapVal: value)
 
@@ -291,7 +291,7 @@ proc callTableMethod*(value: var Table[CirruData, CirruData], exprList: CirruDat
   else:
     raiseEvalError("Unknown method " & exprList[1].symbolVal, exprList[1])
 
-proc callStringMethod*(value: string, exprList: CirruData, interpret: EdnEvalFn, ns: string, scope: CirruDataScope): CirruData =
+proc callStringMethod*(value: string, exprList: CirruData, interpret: EdnEvalFn, scope: CirruDataScope): CirruData =
   if notListData(exprList):
     raiseEvalError(fmt"Expected cirru expr", exprList)
   if exprList.len < 2:
@@ -305,12 +305,12 @@ proc callStringMethod*(value: string, exprList: CirruData, interpret: EdnEvalFn,
   else:
     raiseEvalError("Unknown method " & exprList[1].symbolVal , exprList[1])
 
-proc evalLoadJson*(exprList: CirruData, interpret: EdnEvalFn, ns: string, scope: CirruDataScope): CirruData =
+proc evalLoadJson*(exprList: CirruData, interpret: EdnEvalFn, scope: CirruDataScope): CirruData =
   if notListData(exprList):
     raiseEvalError(fmt"Expected cirru expr", exprList)
   if exprList.len != 2:
     raiseEvalError("load-json requires relative path to json file", exprList[0])
-  let filePath = interpret(exprList[1], ns, scope)
+  let filePath = interpret(exprList[1], scope)
   if filePath.kind != crDataSymbol:
     raiseEvalError("load-json requires path in string", exprList[1])
   let content = readFile(filePath.symbolVal)
@@ -321,12 +321,12 @@ proc evalLoadJson*(exprList: CirruData, interpret: EdnEvalFn, ns: string, scope:
     echo "Failed to parse"
     raiseEvalError("Failed to parse file", exprList[1])
 
-proc evalType*(exprList: CirruData, interpret: EdnEvalFn, ns: string, scope: CirruDataScope): CirruData =
+proc evalType*(exprList: CirruData, interpret: EdnEvalFn, scope: CirruDataScope): CirruData =
   if notListData(exprList):
     raiseEvalError(fmt"Expected cirru expr", exprList)
   if exprList.len != 2:
     raiseEvalError("type gets 1 argument", exprList[0])
-  let v = interpret(exprList[1], ns, scope)
+  let v = interpret(exprList[1], scope)
   case v.kind
     of crDataNil: CirruData(kind: crDataString, stringVal: "nil")
     of crDataNumber: CirruData(kind: crDataString, stringVal: "int")
@@ -337,10 +337,10 @@ proc evalType*(exprList: CirruData, interpret: EdnEvalFn, ns: string, scope: Cir
     of crDataFn: CirruData(kind: crDataString, stringVal: "fn")
     else: CirruData(kind: crDataString, stringVal: "unknown")
 
-proc evalDefn*(exprList: CirruData, interpret: EdnEvalFn, ns: string, scope: CirruDataScope): CirruData =
+proc evalDefn*(exprList: CirruData, interpret: EdnEvalFn, scope: CirruDataScope): CirruData =
   if notListData(exprList):
     raiseEvalError(fmt"Expected cirru expr", exprList)
-  let f = proc(xs: seq[CirruData], interpret2: EdnEvalFn, ns2: string, scope2: CirruDataScope): CirruData =
+  let f = proc(xs: seq[CirruData], interpret2: EdnEvalFn, scope2: CirruDataScope): CirruData =
     let fnScope = CirruDataScope(parent: some(scope))
     let argsList = exprList[2]
     var counter = 0
@@ -353,12 +353,12 @@ proc evalDefn*(exprList: CirruData, interpret: EdnEvalFn, ns: string, scope: Cir
       counter += 1
     var ret = CirruData(kind: crDataNil)
     for child in exprList[3..^1]:
-      ret = interpret(child, ns, fnScope)
+      ret = interpret(child, fnScope)
     return ret
 
   return CirruData(kind: crDataFn, fnVal: f)
 
-proc evalLet*(exprList: CirruData, interpret: EdnEvalFn, ns: string, scope: CirruDataScope): CirruData =
+proc evalLet*(exprList: CirruData, interpret: EdnEvalFn, scope: CirruDataScope): CirruData =
   if notListData(exprList):
     raiseEvalError(fmt"Expected cirru expr", exprList)
   let letScope = CirruDataScope(parent: some(scope))
@@ -377,15 +377,15 @@ proc evalLet*(exprList: CirruData, interpret: EdnEvalFn, ns: string, scope: Cirr
     let value = pair[1]
     if name.kind != crDataSymbol:
       raiseEvalError("Expecting binding name in string", name)
-    letScope.dict[name.symbolVal] = interpret(value, ns, letScope)
+    letScope.dict[name.symbolVal] = interpret(value, letScope)
   result = CirruData(kind: crDataNil)
   for child in body:
-    result = interpret(child, ns, letScope)
+    result = interpret(child, letScope)
 
-proc evalDo*(exprList: CirruData, interpret: EdnEvalFn, ns: string, scope: CirruDataScope): CirruData =
+proc evalDo*(exprList: CirruData, interpret: EdnEvalFn, scope: CirruDataScope): CirruData =
   if notListData(exprList):
     raiseEvalError(fmt"Expected cirru expr", exprList)
   let body = exprList[1..^1]
   result = CirruData(kind: crDataNil)
   for child in body:
-    result = interpret(child, ns, scope)
+    result = interpret(child, scope)

--- a/src/calcitRunner/types.nim
+++ b/src/calcitRunner/types.nim
@@ -38,7 +38,7 @@ type
     crDataFn,
     crDataSymbol,
 
-  EdnEvalFn* = proc(expr: CirruData, ns: string, scope: CirruDataScope): CirruData
+  EdnEvalFn* = proc(expr: CirruData, scope: CirruDataScope): CirruData
 
   CirruData* = object
     line*: int
@@ -50,7 +50,7 @@ type
     of crDataString: stringVal*: string
     of crDataKeyword: keywordVal*: string
     of crDataFn:
-      fnVal*: proc(exprList: seq[CirruData], interpret: EdnEvalFn, ns: string, scope: CirruDataScope): CirruData
+      fnVal*: proc(exprList: seq[CirruData], interpret: EdnEvalFn, scope: CirruDataScope): CirruData
     of crDataVector: vectorVal*: seq[CirruData]
     of crDataList: listVal*: seq[CirruData]
     of crDataSet: setVal*: HashSet[CirruData]

--- a/src/calcitRunner/types.nim
+++ b/src/calcitRunner/types.nim
@@ -36,6 +36,7 @@ type
     crDataSet,
     crDataMap,
     crDataFn,
+    crDataMacro,
     crDataSymbol,
 
   EdnEvalFn* = proc(expr: CirruData, scope: CirruDataScope): CirruData
@@ -51,6 +52,8 @@ type
     of crDataKeyword: keywordVal*: string
     of crDataFn:
       fnVal*: proc(exprList: seq[CirruData], interpret: EdnEvalFn, scope: CirruDataScope): CirruData
+    of crDataMacro:
+      macroVal*: proc(exprList: seq[CirruData], interpret: EdnEvalFn, scope: CirruDataScope): CirruData
     of crDataVector: vectorVal*: seq[CirruData]
     of crDataList: listVal*: seq[CirruData]
     of crDataSet: setVal*: HashSet[CirruData]


### PR DESCRIPTION
Added `eval` `quote` `defmacro`... for a very basic demo,

```cirru
{} (:package |app)
  :configs $ {} (:init-fn |app.main/main!) (:reload-fn |app.main/reload!)
  :files $ {}
    |app.main $ {}
      :ns $ quote
        ns app.main $ :require
      :defs $ {}
        |main! $ quote
          defn main! ()
            eval $ println (+ 1 2)
            println $ quote (+ 1 2)
            println $ gen-num 3 4 c
        |gen-num $ quote
          defmacro gen-num (a b c) (echo a b c) (quote $ + 1 2 3)
      :proc $ quote ()
      :configs $ {} (:extension nil)
```

it evals and prints:

```text
eval: (app.main/println (app.main/+ app.main/1 app.main/2))
3.0
(app.main/+ app.main/1 app.main/2)
app.main/3 app.main/4 app.main/c
6.0
```

Very very naive but cheering!