### PR TITLE
store code on fn/macro for better error stack

### DIFF
--- a/example/calcit.cirru
+++ b/example/calcit.cirru
@@ -186,6 +186,7 @@
               |yyT $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1600749279051)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600749282366) (:text |try-var-args) (:id |cMv3bJEI8hleaf)
+                  |D $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600915728906) (:text |;) (:id |xsXYv8zASO)
                 :id |cMv3bJEI8h
               |r $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1598199469694) (:data $ {}) (:id |_AlBVa6VvM)
               |yvT $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1600585355117)
@@ -206,7 +207,6 @@
               |yyr $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1600772928216)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600772931025) (:text |try-foldl) (:id |GIrwE445Rleaf)
-                  |D $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600875905024) (:text |;) (:id |KeBFkMVrO)
                 :id |GIrwE445R
             :id |-67uVWVTDb
           |try-hygienic $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1600661170630)
@@ -704,14 +704,14 @@
                       |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600835117245) (:text |3) (:id |8WGNW7u4-)
                       |r $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600835117740) (:text |2) (:id |_aN0injrZL)
                     :id |qf6roiW6bU
-                  |D $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600835936604) (:text |;) (:id |OpuCQKK1SA)
+                  |D $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600918005457) (:text |;) (:id |Ps3NK2GsIg)
                 :id |qOnwCWherj
               |yx $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1600836216131)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600836218112) (:text |assert) (:id |eVvPfcTS4leaf)
                   |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600836276345) (:text "|\"asserting value") (:id |ZyVHCcRk4)
                   |r $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600836236396) (:text |false) (:id |W876-Idr6k)
-                  |D $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600836424360) (:text |;) (:id |oPKn52qFaS)
+                  |D $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600917966436) (:text |;) (:id |8XBPETNMz8)
                 :id |eVvPfcTS4
               |t $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1600788124033)
                 :data $ {}

--- a/example/compact.cirru
+++ b/example/compact.cirru
@@ -20,7 +20,7 @@
             println "\"inserting:" $ insert-x 1 2 (3 4 5 $ + 7 8)
             echo $ macroexpand (quote $ gen-num 1 3 4)
         |main! $ quote
-          defn main! () (println "\"Loaded program!") (; try-let) (; try-func) (; try-macro) (; try-hygienic) (; try-core-lib) (try-var-args) (; try-unless) (; try-foldl)
+          defn main! () (println "\"Loaded program!") (; try-let) (; try-func) (; try-macro) (; try-hygienic) (; try-core-lib) (; try-var-args) (; try-unless) (try-foldl)
         |try-hygienic $ quote
           defn try-hygienic ()
             let

--- a/src/calcitRunner.nim
+++ b/src/calcitRunner.nim
@@ -169,7 +169,7 @@ proc interpret(expr: CirruData, scope: CirruDataScope): CirruData =
               args.add interpret(x, scope)
 
             let code = CirruData(kind: crDataList, listVal: getListDataSeq(value.fnCode))
-            pushDefStack(StackInfo(ns: head.ns, def: head.symbolVal, code: code))
+            pushDefStack(StackInfo(ns: head.ns, def: head.symbolVal, code: code, args: args))
             let ret = f(args, interpret, scope)
             popDefStack()
             return ret
@@ -178,7 +178,7 @@ proc interpret(expr: CirruData, scope: CirruDataScope): CirruData =
             let quoted = f(expr[1..^1], interpret, scope)
 
             let code = CirruData(kind: crDataList, listVal: getListDataSeq(value.macroCode))
-            pushDefStack(StackInfo(ns: head.ns, def: head.symbolVal, code: code))
+            pushDefStack(StackInfo(ns: head.ns, def: head.symbolVal, code: code, args: expr[1..^1]))
             let ret = interpret(quoted, scope)
             popDefStack()
             return ret
@@ -232,6 +232,7 @@ proc showStack(): void =
   for item in errorStack:
     echo item.ns, "/", item.def
     dimEcho $item.code
+    dimEcho "args: ", $CirruData(kind: crDataList, listVal: item.args)
 
 proc runProgram*(snapshotFile: string, initFn: Option[string] = none(string)): CirruData =
   programCode = loadSnapshot(snapshotFile)

--- a/src/calcitRunner.nim
+++ b/src/calcitRunner.nim
@@ -167,14 +167,18 @@ proc interpret(expr: CirruData, scope: CirruDataScope): CirruData =
             let argsCode = expr[1..^1]
             for x in argsCode:
               args.add interpret(x, scope)
-            pushDefStack(StackInfo(ns: head.ns, def: head.symbolVal))
+
+            let code = CirruData(kind: crDataList, listVal: getListDataSeq(value.fnCode))
+            pushDefStack(StackInfo(ns: head.ns, def: head.symbolVal, code: code))
             let ret = f(args, interpret, scope)
             popDefStack()
             return ret
           of crDataMacro:
             let f = value.macroVal
             let quoted = f(expr[1..^1], interpret, scope)
-            pushDefStack(StackInfo(ns: head.ns, def: head.symbolVal))
+
+            let code = CirruData(kind: crDataList, listVal: getListDataSeq(value.macroCode))
+            pushDefStack(StackInfo(ns: head.ns, def: head.symbolVal, code: code))
             let ret = interpret(quoted, scope)
             popDefStack()
             return ret
@@ -226,14 +230,8 @@ proc loadImportDictByNs(ns: string): Table[string, ImportInfo] =
 proc showStack(): void =
   let errorStack = reversed(defStack)
   for item in errorStack:
-    if hasNsAndDef(item.ns, item.def):
-      echo item.ns, "/", item.def
-      dimEcho shortenCode($programCode[item.ns].defs[item.def], 400)
-    elif hasNsAndDef(coreNs, item.def):
-      echo coreNs, "/", item.def
-      dimEcho shortenCode($programCode[coreNs].defs[item.def], 400)
-    else:
-      echo item.ns, "/", item.def, " (local binding)"
+    echo item.ns, "/", item.def
+    dimEcho $item.code
 
 proc runProgram*(snapshotFile: string, initFn: Option[string] = none(string)): CirruData =
   programCode = loadSnapshot(snapshotFile)
@@ -256,7 +254,8 @@ proc runProgram*(snapshotFile: string, initFn: Option[string] = none(string)): C
   if entry.kind != crDataFn:
     raise newException(ValueError, "expects a function at app.main/main!")
 
-  defStack = @[StackInfo(ns: pieces[0], def: pieces[1])]
+  let mainCode = programCode[pieces[0]].defs[pieces[1]]
+  defStack = @[StackInfo(ns: pieces[0], def: pieces[1], code: mainCode)]
 
   let f = entry.fnVal
   let args: seq[CirruData] = @[]
@@ -294,7 +293,8 @@ proc reloadProgram(snapshotFile: string): void =
   if entry.kind != crDataFn:
     raise newException(ValueError, "expects a function at app.main/main!")
 
-  defStack = @[StackInfo(ns: pieces[0], def: pieces[1])]
+  let mainCode = programCode[pieces[0]].defs[pieces[1]]
+  defStack = @[StackInfo(ns: pieces[0], def: pieces[1], code: mainCode)]
 
   let f = entry.fnVal
   let args: seq[CirruData] = @[]

--- a/src/calcitRunner.nim
+++ b/src/calcitRunner.nim
@@ -168,8 +168,7 @@ proc interpret(expr: CirruData, scope: CirruDataScope): CirruData =
             for x in argsCode:
               args.add interpret(x, scope)
 
-            let code = CirruData(kind: crDataList, listVal: getListDataSeq(value.fnCode))
-            pushDefStack(StackInfo(ns: head.ns, def: head.symbolVal, code: code, args: args))
+            pushDefStack(StackInfo(ns: head.ns, def: head.symbolVal, code: value.fnCode, args: args))
             let ret = f(args, interpret, scope)
             popDefStack()
             return ret
@@ -177,8 +176,7 @@ proc interpret(expr: CirruData, scope: CirruDataScope): CirruData =
             let f = value.macroVal
             let quoted = f(expr[1..^1], interpret, scope)
 
-            let code = CirruData(kind: crDataList, listVal: getListDataSeq(value.macroCode))
-            pushDefStack(StackInfo(ns: head.ns, def: head.symbolVal, code: code, args: expr[1..^1]))
+            pushDefStack(StackInfo(ns: head.ns, def: head.symbolVal, code: value.macroCode, args: expr[1..^1]))
             let ret = interpret(quoted, scope)
             popDefStack()
             return ret
@@ -256,7 +254,8 @@ proc runProgram*(snapshotFile: string, initFn: Option[string] = none(string)): C
     raise newException(ValueError, "expects a function at app.main/main!")
 
   let mainCode = programCode[pieces[0]].defs[pieces[1]]
-  defStack = @[StackInfo(ns: pieces[0], def: pieces[1], code: mainCode)]
+  let refCode = RefCirruData(kind: crDataList, listVal: getListDataSeq(mainCode))
+  defStack = @[StackInfo(ns: pieces[0], def: pieces[1], code: refCode)]
 
   let f = entry.fnVal
   let args: seq[CirruData] = @[]
@@ -295,7 +294,8 @@ proc reloadProgram(snapshotFile: string): void =
     raise newException(ValueError, "expects a function at app.main/main!")
 
   let mainCode = programCode[pieces[0]].defs[pieces[1]]
-  defStack = @[StackInfo(ns: pieces[0], def: pieces[1], code: mainCode)]
+  let refCode = RefCirruData(kind: crDataList, listVal: getListDataSeq(mainCode))
+  defStack = @[StackInfo(ns: pieces[0], def: pieces[1], code: refCode)]
 
   let f = entry.fnVal
   let args: seq[CirruData] = @[]

--- a/src/calcitRunner/coreLib.nim
+++ b/src/calcitRunner/coreLib.nim
@@ -223,31 +223,39 @@ proc nativeMacroexpand*(args: seq[CirruData], interpret: EdnEvalFn, scope: Cirru
 
 # TODO reduce-find
 
+
+proc fakeNativeCode(info: string): RefCirruData =
+  RefCirruData(kind: crDataList, listVal: @[
+    CirruData(kind: crDataSymbol, symbolVal: "defnative", ns: coreNs),
+    CirruData(kind: crDataSymbol, symbolVal: info, ns: coreNs),
+    CirruData(kind: crDataSymbol, symbolVal: "__native_code__", ns: coreNs)
+  ])
+
 # injecting functions to calcit.core directly
 proc loadCoreDefs*(programData: var Table[string, ProgramFile], programCode: var Table[string, FileSource], interpret: EdnEvalFn): void =
   var coreFile: ProgramFile
   var coreSource: FileSource
   let rootScope = CirruDataScope()
 
-  coreFile.defs["&+"] = CirruData(kind: crDataFn, fnVal: nativeAdd)
-  coreFile.defs["&-"] = CirruData(kind: crDataFn, fnVal: nativeMinus)
-  coreFile.defs["&*"] = CirruData(kind: crDataFn, fnVal: nativeMultiply)
-  coreFile.defs["&/"] = CirruData(kind: crDataFn, fnVal: nativeDivide)
-  coreFile.defs["&<"] = CirruData(kind: crDataFn, fnVal: nativeLessThan)
-  coreFile.defs["&>"] = CirruData(kind: crDataFn, fnVal: nativeGreaterThan)
-  coreFile.defs["&="] = CirruData(kind: crDataFn, fnVal: nativeEqual)
-  coreFile.defs["&and"] = CirruData(kind: crDataFn, fnVal: nativeAnd)
-  coreFile.defs["&or"] = CirruData(kind: crDataFn, fnVal: nativeOr)
-  coreFile.defs["not"] = CirruData(kind: crDataFn, fnVal: nativeNot)
-  coreFile.defs["count"] = CirruData(kind: crDataFn, fnVal: nativeCount)
-  coreFile.defs["get"] = CirruData(kind: crDataFn, fnVal: nativeGet)
-  coreFile.defs["rest"] = CirruData(kind: crDataFn, fnVal: nativeRest)
-  coreFile.defs["raise-at"] = CirruData(kind: crDataFn, fnVal: nativeRaiseAt)
-  coreFile.defs["type-of"] = CirruData(kind: crDataFn, fnVal: nativeTypeOf)
-  coreFile.defs["read-file"] = CirruData(kind: crDataFn, fnVal: nativeReadFile)
-  coreFile.defs["write-file"] = CirruData(kind: crDataFn, fnVal: nativeWriteFile)
-  coreFile.defs["load-json"] = CirruData(kind: crDataFn, fnVal: nativeLoadJson)
-  coreFile.defs["macroexpand"] = CirruData(kind: crDataFn, fnVal: nativeMacroexpand)
+  coreFile.defs["&+"] = CirruData(kind: crDataFn, fnVal: nativeAdd, fnCode: fakeNativeCode("&+"))
+  coreFile.defs["&-"] = CirruData(kind: crDataFn, fnVal: nativeMinus, fnCode: fakeNativeCode("&-"))
+  coreFile.defs["&*"] = CirruData(kind: crDataFn, fnVal: nativeMultiply, fnCode: fakeNativeCode("&*"))
+  coreFile.defs["&/"] = CirruData(kind: crDataFn, fnVal: nativeDivide, fnCode: fakeNativeCode("&/"))
+  coreFile.defs["&<"] = CirruData(kind: crDataFn, fnVal: nativeLessThan, fnCode: fakeNativeCode("&<"))
+  coreFile.defs["&>"] = CirruData(kind: crDataFn, fnVal: nativeGreaterThan, fnCode: fakeNativeCode("&>"))
+  coreFile.defs["&="] = CirruData(kind: crDataFn, fnVal: nativeEqual, fnCode: fakeNativeCode("&="))
+  coreFile.defs["&and"] = CirruData(kind: crDataFn, fnVal: nativeAnd, fnCode: fakeNativeCode("&and"))
+  coreFile.defs["&or"] = CirruData(kind: crDataFn, fnVal: nativeOr, fnCode: fakeNativeCode("&or"))
+  coreFile.defs["not"] = CirruData(kind: crDataFn, fnVal: nativeNot, fnCode: fakeNativeCode("not"))
+  coreFile.defs["count"] = CirruData(kind: crDataFn, fnVal: nativeCount, fnCode: fakeNativeCode("count"))
+  coreFile.defs["get"] = CirruData(kind: crDataFn, fnVal: nativeGet, fnCode: fakeNativeCode("get"))
+  coreFile.defs["rest"] = CirruData(kind: crDataFn, fnVal: nativeRest, fnCode: fakeNativeCode("rest"))
+  coreFile.defs["raise-at"] = CirruData(kind: crDataFn, fnVal: nativeRaiseAt, fnCode: fakeNativeCode("raise-at"))
+  coreFile.defs["type-of"] = CirruData(kind: crDataFn, fnVal: nativeTypeOf, fnCode: fakeNativeCode("type-of"))
+  coreFile.defs["read-file"] = CirruData(kind: crDataFn, fnVal: nativeReadFile, fnCode: fakeNativeCode("read-file"))
+  coreFile.defs["write-file"] = CirruData(kind: crDataFn, fnVal: nativeWriteFile, fnCode: fakeNativeCode("write-file"))
+  coreFile.defs["load-json"] = CirruData(kind: crDataFn, fnVal: nativeLoadJson, fnCode: fakeNativeCode("load-json"))
+  coreFile.defs["macroexpand"] = CirruData(kind: crDataFn, fnVal: nativeMacroexpand, fnCode: fakeNativeCode("macroexpand"))
 
   let codeUnless = (%*
     ["defmacro", "unless", ["cond", "true-branch", "false-branch"],

--- a/src/calcitRunner/data.nim
+++ b/src/calcitRunner/data.nim
@@ -346,6 +346,15 @@ proc getListDataSeq*(xs: RefCirruData): seq[CirruData] =
   else:
     raise newException(ValueError, "Cannot get seq code from data")
 
+proc getListDataSeq*(xs: CirruData): seq[CirruData] =
+  case xs.kind
+  of crDataVector:
+    return xs.vectorVal
+  of crDataList:
+    return xs.listVal
+  else:
+    raise newException(ValueError, "Cannot get seq code from data")
+
 proc `[]`*(xs: CirruData, fromTo: HSlice[int, int]): seq[CirruData] =
   if notListData(xs):
     raise newException(ValueError, "Cannot create iterator on a cirru string")

--- a/src/calcitRunner/data.nim
+++ b/src/calcitRunner/data.nim
@@ -337,6 +337,15 @@ proc isListData*(xs: CirruData): bool =
 proc notListData*(xs: CirruData): bool =
   not isListData(xs)
 
+proc getListDataSeq*(xs: RefCirruData): seq[CirruData] =
+  case xs.kind
+  of crDataVector:
+    return xs.vectorVal
+  of crDataList:
+    return xs.listVal
+  else:
+    raise newException(ValueError, "Cannot get seq code from data")
+
 proc `[]`*(xs: CirruData, fromTo: HSlice[int, int]): seq[CirruData] =
   if notListData(xs):
     raise newException(ValueError, "Cannot create iterator on a cirru string")

--- a/src/calcitRunner/format.nim
+++ b/src/calcitRunner/format.nim
@@ -52,8 +52,8 @@ proc toString*(val: CirruData, details: bool = false): string =
     of crDataMap: fromTableToString(val.mapVal)
     of crDataNil: "nil"
     of crDataKeyword: ":" & val.keywordVal
-    of crDataFn: "::fn"
-    of crDataMacro: "::macro"
+    of crDataFn: "<Function>"
+    of crDataMacro: "<Macro>"
     of crDataSymbol:
       if details:
         if val.scope.isSome:

--- a/src/calcitRunner/format.nim
+++ b/src/calcitRunner/format.nim
@@ -6,7 +6,7 @@ import options
 
 import ./types
 
-proc toString*(val: CirruData, details: bool = false): string
+proc toString*(val: CirruData | RefCirruData, details: bool = false): string
 
 proc fromArrayToString(children: seq[CirruData]): string =
   return "[" & children.mapIt(toString(it)).join(" ") & "]"
@@ -37,7 +37,7 @@ proc escapeString(x: string): string =
   else:
     x
 
-proc toString*(val: CirruData, details: bool = false): string =
+proc toString*(val: CirruData | RefCirruData, details: bool = false): string =
   case val.kind:
     of crDataBool:
       if val.boolVal:
@@ -63,37 +63,7 @@ proc toString*(val: CirruData, details: bool = false): string =
       else:
         val.symbolVal
 
-# TODO, better to be generated from toString
-proc toString*(val: RefCirruData, details: bool = false): string =
-  case val.kind:
-    of crDataBool:
-      if val.boolVal:
-        "true"
-      else:
-        "false"
-    of crDataNumber: $(val.numberVal)
-    of crDataString: val.stringVal
-    of crDataVector: fromArrayToString(val.vectorVal)
-    of crDataList: fromSeqToString(val.listVal)
-    of crDataSet: fromSetToString(val.setVal)
-    of crDataMap: fromTableToString(val.mapVal)
-    of crDataNil: "nil"
-    of crDataKeyword: ":" & val.keywordVal
-    of crDataFn: "<Function>"
-    of crDataMacro: "<Macro>"
-    of crDataSymbol:
-      if details:
-        if val.scope.isSome:
-          "scoped::" & val.ns & "/" & escapeString(val.symbolVal)
-        else:
-          val.ns & "/" & escapeString(val.symbolVal)
-      else:
-        val.symbolVal
-
-proc `$`*(v: CirruData): string =
-  v.toString(false)
-
-proc `$`*(v: RefCirruData): string =
+proc `$`*(v: CirruData | RefCirruData): string =
   v.toString(false)
 
 proc shortenCode*(code: string, n: int): string =

--- a/src/calcitRunner/format.nim
+++ b/src/calcitRunner/format.nim
@@ -63,7 +63,37 @@ proc toString*(val: CirruData, details: bool = false): string =
       else:
         val.symbolVal
 
+# TODO, better to be generated from toString
+proc toString*(val: RefCirruData, details: bool = false): string =
+  case val.kind:
+    of crDataBool:
+      if val.boolVal:
+        "true"
+      else:
+        "false"
+    of crDataNumber: $(val.numberVal)
+    of crDataString: val.stringVal
+    of crDataVector: fromArrayToString(val.vectorVal)
+    of crDataList: fromSeqToString(val.listVal)
+    of crDataSet: fromSetToString(val.setVal)
+    of crDataMap: fromTableToString(val.mapVal)
+    of crDataNil: "nil"
+    of crDataKeyword: ":" & val.keywordVal
+    of crDataFn: "<Function>"
+    of crDataMacro: "<Macro>"
+    of crDataSymbol:
+      if details:
+        if val.scope.isSome:
+          "scoped::" & val.ns & "/" & escapeString(val.symbolVal)
+        else:
+          val.ns & "/" & escapeString(val.symbolVal)
+      else:
+        val.symbolVal
+
 proc `$`*(v: CirruData): string =
+  v.toString(false)
+
+proc `$`*(v: RefCirruData): string =
   v.toString(false)
 
 proc shortenCode*(code: string, n: int): string =

--- a/src/calcitRunner/specialForm.nim
+++ b/src/calcitRunner/specialForm.nim
@@ -244,7 +244,12 @@ proc evalDefn*(exprList: CirruData, interpret: EdnEvalFn, scope: CirruDataScope)
       ret = interpret(child, innerScope)
     return ret
 
-  return CirruData(kind: crDataFn, fnVal: f)
+  if exprList.kind == crDataVector:
+    let code = RefCirruData(kind: crDataList, listVal: exprList.vectorVal)
+    return CirruData(kind: crDataFn, fnVal: f, fnCode: code)
+  else:
+    let code = RefCirruData(kind: crDataList, listVal: exprList.listVal)
+    return CirruData(kind: crDataFn, fnVal: f, fnCode: code)
 
 proc evalLet*(exprList: CirruData, interpret: EdnEvalFn, scope: CirruDataScope): CirruData =
   if notListData(exprList):
@@ -364,7 +369,12 @@ proc evalDefmacro*(exprList: CirruData, interpret: EdnEvalFn, scope: CirruDataSc
       raiseEvalError("Expected cirru expr from defmacro", ret)
     return ret
 
-  return CirruData(kind: crDataMacro, macroVal: f)
+  if exprList.kind == crDataVector:
+    let code = RefCirruData(kind: crDataList, listVal: exprList.vectorVal)
+    return CirruData(kind: crDataMacro, macroVal: f, macroCode: code)
+  else:
+    let code = RefCirruData(kind: crDataList, listVal: exprList.listVal)
+    return CirruData(kind: crDataMacro, macroVal: f, macroCode: code)
 
 proc evalAssert*(exprList: CirruData, interpret: EdnEvalFn, scope: CirruDataScope): CirruData =
   if notListData(exprList):

--- a/src/calcitRunner/types.nim
+++ b/src/calcitRunner/types.nim
@@ -15,10 +15,6 @@ type ImportInfo* = object
   of importDef:
     def*: string
 
-type StackInfo* = object
-  ns*: string
-  def*: string
-
 type
 
   CirruDataScope* = ref object
@@ -54,8 +50,10 @@ type
     of crDataKeyword: keywordVal*: string
     of crDataFn:
       fnVal*: FnInData
+      fnCode*: ref CirruData
     of crDataMacro:
       macroVal*: FnInData
+      macroCode*: ref CirruData
     of crDataVector: vectorVal*: seq[CirruData]
     of crDataList: listVal*: seq[CirruData]
     of crDataSet: setVal*: HashSet[CirruData]
@@ -89,3 +87,10 @@ type FileSource* = object
   ns*: CirruData
   run*: CirruData
   defs*: Table[string, CirruData]
+
+type StackInfo* = object
+  ns*: string
+  def*: string
+  code*: CirruData
+
+type RefCirruData* = ref CirruData

--- a/src/calcitRunner/types.nim
+++ b/src/calcitRunner/types.nim
@@ -92,5 +92,6 @@ type StackInfo* = object
   ns*: string
   def*: string
   code*: CirruData
+  args*: seq[CirruData]
 
 type RefCirruData* = ref CirruData

--- a/src/calcitRunner/types.nim
+++ b/src/calcitRunner/types.nim
@@ -91,7 +91,7 @@ type FileSource* = object
 type StackInfo* = object
   ns*: string
   def*: string
-  code*: CirruData
+  code*: ref CirruData
   args*: seq[CirruData]
 
 type RefCirruData* = ref CirruData


### PR DESCRIPTION
This change has some extra memory usages since each function and macro now contains a reference to a copy of its code data. Personally I would prefer practicability over performance in this stage. We could just use nim if we want performance.

Good part is stack information looks better for native and anonymous functions:

![image](https://user-images.githubusercontent.com/449224/94098562-76fd1d00-fe5b-11ea-8c65-ce129eb632b6.png)

