### PR TITLE
use fewer ref to reduce confusions

### DIFF
--- a/src/calcitRunner.nim
+++ b/src/calcitRunner.nim
@@ -168,7 +168,7 @@ proc interpret(expr: CirruData, scope: CirruDataScope): CirruData =
             for x in argsCode:
               args.add interpret(x, scope)
 
-            pushDefStack(StackInfo(ns: head.ns, def: head.symbolVal, code: value.fnCode, args: args))
+            pushDefStack(StackInfo(ns: head.ns, def: head.symbolVal, code: value.fnCode[], args: args))
             let ret = f(args, interpret, scope)
             popDefStack()
             return ret
@@ -176,7 +176,7 @@ proc interpret(expr: CirruData, scope: CirruDataScope): CirruData =
             let f = value.macroVal
             let quoted = f(expr[1..^1], interpret, scope)
 
-            pushDefStack(StackInfo(ns: head.ns, def: head.symbolVal, code: value.macroCode, args: expr[1..^1]))
+            pushDefStack(StackInfo(ns: head.ns, def: head.symbolVal, code: value.macroCode[], args: expr[1..^1]))
             let ret = interpret(quoted, scope)
             popDefStack()
             return ret
@@ -254,8 +254,7 @@ proc runProgram*(snapshotFile: string, initFn: Option[string] = none(string)): C
     raise newException(ValueError, "expects a function at app.main/main!")
 
   let mainCode = programCode[pieces[0]].defs[pieces[1]]
-  let refCode = RefCirruData(kind: crDataList, listVal: getListDataSeq(mainCode))
-  defStack = @[StackInfo(ns: pieces[0], def: pieces[1], code: refCode)]
+  defStack = @[StackInfo(ns: pieces[0], def: pieces[1], code: mainCode)]
 
   let f = entry.fnVal
   let args: seq[CirruData] = @[]
@@ -277,7 +276,6 @@ proc runProgram*(snapshotFile: string, initFn: Option[string] = none(string)): C
     raise e
 
 proc reloadProgram(snapshotFile: string): void =
-  defStack = @[]
   programCode = loadSnapshot(snapshotFile)
   clearProgramDefs(programData)
   var scope = CirruDataScope(parent: none(CirruDataScope))
@@ -294,8 +292,7 @@ proc reloadProgram(snapshotFile: string): void =
     raise newException(ValueError, "expects a function at app.main/main!")
 
   let mainCode = programCode[pieces[0]].defs[pieces[1]]
-  let refCode = RefCirruData(kind: crDataList, listVal: getListDataSeq(mainCode))
-  defStack = @[StackInfo(ns: pieces[0], def: pieces[1], code: refCode)]
+  defStack = @[StackInfo(ns: pieces[0], def: pieces[1], code: mainCode)]
 
   let f = entry.fnVal
   let args: seq[CirruData] = @[]

--- a/src/calcitRunner/coreLib.nim
+++ b/src/calcitRunner/coreLib.nim
@@ -215,14 +215,12 @@ proc nativeMacroexpand*(args: seq[CirruData], interpret: EdnEvalFn, scope: Cirru
   let quoted = f(code[1..^1], interpret, scope)
   return quoted
 
-
 # TODO keyword
 # TODO symbol
 
 # TODO load edn
 
 # TODO reduce-find
-
 
 proc fakeNativeCode(info: string): RefCirruData =
   RefCirruData(kind: crDataList, listVal: @[

--- a/src/calcitRunner/data.nim
+++ b/src/calcitRunner/data.nim
@@ -337,15 +337,6 @@ proc isListData*(xs: CirruData): bool =
 proc notListData*(xs: CirruData): bool =
   not isListData(xs)
 
-proc getListDataSeq*(xs: RefCirruData): seq[CirruData] =
-  case xs.kind
-  of crDataVector:
-    return xs.vectorVal
-  of crDataList:
-    return xs.listVal
-  else:
-    raise newException(ValueError, "Cannot get seq code from data")
-
 proc getListDataSeq*(xs: CirruData): seq[CirruData] =
   case xs.kind
   of crDataVector:

--- a/src/calcitRunner/format.nim
+++ b/src/calcitRunner/format.nim
@@ -6,7 +6,7 @@ import options
 
 import ./types
 
-proc toString*(val: CirruData | RefCirruData, details: bool = false): string
+proc toString*(val: CirruData, details: bool = false): string
 
 proc fromArrayToString(children: seq[CirruData]): string =
   return "[" & children.mapIt(toString(it)).join(" ") & "]"
@@ -37,7 +37,7 @@ proc escapeString(x: string): string =
   else:
     x
 
-proc toString*(val: CirruData | RefCirruData, details: bool = false): string =
+proc toString*(val: CirruData, details: bool = false): string =
   case val.kind:
     of crDataBool:
       if val.boolVal:
@@ -63,7 +63,7 @@ proc toString*(val: CirruData | RefCirruData, details: bool = false): string =
       else:
         val.symbolVal
 
-proc `$`*(v: CirruData | RefCirruData): string =
+proc `$`*(v: CirruData): string =
   v.toString(false)
 
 proc shortenCode*(code: string, n: int): string =

--- a/src/calcitRunner/specialForm.nim
+++ b/src/calcitRunner/specialForm.nim
@@ -244,12 +244,8 @@ proc evalDefn*(exprList: CirruData, interpret: EdnEvalFn, scope: CirruDataScope)
       ret = interpret(child, innerScope)
     return ret
 
-  if exprList.kind == crDataVector:
-    let code = RefCirruData(kind: crDataList, listVal: exprList.vectorVal)
-    return CirruData(kind: crDataFn, fnVal: f, fnCode: code)
-  else:
-    let code = RefCirruData(kind: crDataList, listVal: exprList.listVal)
-    return CirruData(kind: crDataFn, fnVal: f, fnCode: code)
+  let code = RefCirruData(kind: crDataList, listVal: getListDataSeq(exprList))
+  return CirruData(kind: crDataFn, fnVal: f, fnCode: code)
 
 proc evalLet*(exprList: CirruData, interpret: EdnEvalFn, scope: CirruDataScope): CirruData =
   if notListData(exprList):
@@ -369,12 +365,8 @@ proc evalDefmacro*(exprList: CirruData, interpret: EdnEvalFn, scope: CirruDataSc
       raiseEvalError("Expected cirru expr from defmacro", ret)
     return ret
 
-  if exprList.kind == crDataVector:
-    let code = RefCirruData(kind: crDataList, listVal: exprList.vectorVal)
-    return CirruData(kind: crDataMacro, macroVal: f, macroCode: code)
-  else:
-    let code = RefCirruData(kind: crDataList, listVal: exprList.listVal)
-    return CirruData(kind: crDataMacro, macroVal: f, macroCode: code)
+  let code = RefCirruData(kind: crDataList, listVal: getListDataSeq(exprList))
+  return CirruData(kind: crDataMacro, macroVal: f, macroCode: code)
 
 proc evalAssert*(exprList: CirruData, interpret: EdnEvalFn, scope: CirruDataScope): CirruData =
   if notListData(exprList):

--- a/src/calcitRunner/types.nim
+++ b/src/calcitRunner/types.nim
@@ -91,7 +91,7 @@ type FileSource* = object
 type StackInfo* = object
   ns*: string
   def*: string
-  code*: ref CirruData
+  code*: CirruData
   args*: seq[CirruData]
 
 type RefCirruData* = ref CirruData


### PR DESCRIPTION
There's still costs in copying CirruData. However using refs does not surely makes code faster.
