### PR TITLE
reduce syntax with macro expansion; remove duplicated tests

### DIFF
--- a/src/calcit_runner/core_abstract.nim
+++ b/src/calcit_runner/core_abstract.nim
@@ -513,6 +513,17 @@ proc loadCoreFuncs*(programCode: var Table[string, FileSource]) =
         ["quote-replace", ["[]", ["~@", items]]]]]
     , coreNs)
 
+  let codeMapSyntax = genCirru(
+    [defmacro, "{}", ["&", xs],
+      ["let", [[ys, [map, [fn, [x], ["quote-replace", ["[]", ["~@", x]]]], xs]]],
+        ["quote-replace", ["&{}", ["~@", ys]]]]]
+  , coreNs)
+
+  let codeFn = genCirru(
+    [defmacro, fn, [args, "&", body],
+      ["quote-replace", [defn, "generated-fn", ["~", args], ["~@", body]]]]
+  , coreNs)
+
   # TODO assoc-in
   # TODO dissoc-in
   # TODO update-in
@@ -591,3 +602,5 @@ proc loadCoreFuncs*(programCode: var Table[string, FileSource]) =
   programCode[coreNs].defs["section-by"] = codeSectionBy
   programCode[coreNs].defs["g"] = codeG
   programCode[coreNs].defs["[][]"] = codeListList
+  programCode[coreNs].defs["{}"] = codeMapSyntax
+  programCode[coreNs].defs["fn"] = codeFn

--- a/src/calcit_runner/core_func.nim
+++ b/src/calcit_runner/core_func.nim
@@ -845,6 +845,16 @@ proc nativeToPairs(args: seq[CirruData], interpret: FnInterpret, scope: CirruDat
     acc.add CirruData(kind: crDataList, listVal: list)
   return CirruData(kind: crDataList, listVal: initTernaryTreeList(acc))
 
+proc nativeMap*(exprList: seq[CirruData], interpret: FnInterpret, scope: CirruDataScope): CirruData =
+  var value = initTable[CirruData, CirruData]()
+  for pair in exprList:
+    if pair.kind != crDataList:
+      raiseEvalError("Map requires nested children pairs", pair)
+    if pair.len() != 2:
+      raiseEvalError("Each pair of table contains 2 elements", pair)
+    value[pair[0]] = pair[1]
+  return CirruData(kind: crDataMap, mapVal: initTernaryTreeMap(value))
+
 # injecting functions to calcit.core directly
 proc loadCoreDefs*(programData: var Table[string, ProgramFile], interpret: FnInterpret): void =
   programData[coreNs].defs["&+"] = CirruData(kind: crDataProc, procVal: nativeAdd)
@@ -917,3 +927,4 @@ proc loadCoreDefs*(programData: var Table[string, ProgramFile], interpret: FnInt
   programData[coreNs].defs["split"] = CirruData(kind: crDataProc, procVal: nativeSplit)
   programData[coreNs].defs["split-lines"] = CirruData(kind: crDataProc, procVal: nativeSplitLines)
   programData[coreNs].defs["to-pairs"] = CirruData(kind: crDataProc, procVal: nativeToPairs)
+  programData[coreNs].defs["&{}"] = CirruData(kind: crDataProc, procVal: nativeMap)

--- a/src/calcit_runner/core_syntax.nim
+++ b/src/calcit_runner/core_syntax.nim
@@ -50,18 +50,6 @@ proc nativeIf*(exprList: seq[CirruData], interpret: FnInterpret, scope: CirruDat
 proc nativeComment(exprList: seq[CirruData], interpret: FnInterpret, scope: CirruDataScope): CirruData =
   return CirruData(kind: crDataNil)
 
-proc nativeMap*(exprList: seq[CirruData], interpret: FnInterpret, scope: CirruDataScope): CirruData =
-  var value = initTable[CirruData, CirruData]()
-  for pair in exprList:
-    if pair.kind != crDataList:
-      raiseEvalError("Table requires nested children pairs", pair)
-    if pair.len() != 2:
-      raiseEvalError("Each pair of table contains 2 elements", pair)
-    let k = interpret(pair[0], scope)
-    let v = interpret(pair[1], scope)
-    value[k] = v
-  return CirruData(kind: crDataMap, mapVal: initTernaryTreeMap(value))
-
 proc nativeDefn(exprList: seq[CirruData], interpret: FnInterpret, scope: CirruDataScope): CirruData =
   if exprList.len < 2: raiseEvalError("Expects name and args for defn", exprList)
   let fnName = exprList[0]
@@ -69,12 +57,6 @@ proc nativeDefn(exprList: seq[CirruData], interpret: FnInterpret, scope: CirruDa
   let argsList = exprList[1]
   if argsList.kind != crDataList: raiseEvalError("Expects args to be list", exprList)
   return CirruData(kind: crDataFn, fnName: fnName.symbolVal, fnArgs: argsList.listVal, fnCode: exprList[2..^1], fnScope: scope)
-
-proc nativeFn(exprList: seq[CirruData], interpret: FnInterpret, scope: CirruDataScope): CirruData =
-  if exprList.len < 1: raiseEvalError("Expects args for fn", exprList)
-  let argsList = exprList[0]
-  if argsList.kind != crDataList: raiseEvalError("Expects args to be list", exprList)
-  return CirruData(kind: crDataFn, fnName: "fn", fnArgs: argsList.listVal, fnCode: exprList[1..^1], fnScope: scope)
 
 proc nativeLet(exprList: seq[CirruData], interpret: FnInterpret, scope: CirruDataScope): CirruData =
   var letScope = scope
@@ -235,8 +217,6 @@ proc loadCoreSyntax*(programData: var Table[string, ProgramFile], interpret: FnI
   programData[coreNs].defs["do"] = CirruData(kind: crDataSyntax, syntaxVal: nativeDo)
   programData[coreNs].defs["if"] = CirruData(kind: crDataSyntax, syntaxVal: nativeIf)
   programData[coreNs].defs["defn"] = CirruData(kind: crDataSyntax, syntaxVal: nativeDefn)
-  programData[coreNs].defs["fn"] = CirruData(kind: crDataSyntax, syntaxVal: nativeFn)
   programData[coreNs].defs["let"] = CirruData(kind: crDataSyntax, syntaxVal: nativeLet)
   programData[coreNs].defs["quote"] = CirruData(kind: crDataSyntax, syntaxVal: nativeQuote)
-  programData[coreNs].defs["{}"] = CirruData(kind: crDataSyntax, syntaxVal: nativeMap)
   programData[coreNs].defs["loop"] = CirruData(kind: crDataSyntax, syntaxVal: nativeLoop)

--- a/src/calcit_runner/evaluate.nim
+++ b/src/calcit_runner/evaluate.nim
@@ -280,14 +280,10 @@ proc preprocess(code: CirruData, localDefs: Hashset[string]): CirruData =
           return code
         of "defn", "defmacro":
           return processDefn(code, localDefs, preprocessHelper)
-        of "fn":
-          return processFn(code, localDefs, preprocessHelper)
         of "let", "loop":
           return processBinding(code, localDefs, preprocessHelper)
         of "[]", "if", "assert", "do", "quote-replace":
           return processAll(code, localDefs, preprocessHelper)
-        of "{}":
-          return processMap(code, localDefs, preprocessHelper)
         of "quote":
           return processQuote(code, localDefs, preprocessHelper)
         else:

--- a/src/calcit_runner/preprocess.nim
+++ b/src/calcit_runner/preprocess.nim
@@ -24,30 +24,6 @@ proc processAll*(xs: CirruData, localDefs: Hashset[string], preprocess: FnPrepro
     ys = ys.append preprocess(item, localDefs)
   return CirruData(kind: crDataList, listVal: ys)
 
-proc processMap*(xs: CirruData, localDefs: Hashset[string], preprocess: FnPreprocess): CirruData =
-  if xs.kind != crDataList:
-    raiseEvalError("Expects a list", xs)
-  if xs.len < 1:
-    raiseEvalError("Expects len >1", xs)
-
-  let head = xs[0]
-  let body = xs.listVal.rest()
-
-  var ys = initTernaryTreeList[CirruData](@[head])
-  for pair in body:
-    if pair.kind != crDataList:
-      raiseEvalError("Expects a list", xs)
-    if pair.len != 2:
-      raiseEvalError("Expects len of 2", pair)
-
-    let newPair = CirruData(kind: crDataList, listVal: initTernaryTreeList(@[
-      preprocess(pair[0], localDefs),
-      preprocess(pair[1], localDefs),
-    ]))
-    ys = ys.append newPair
-
-  return CirruData(kind: crDataList, listVal: ys)
-
 proc processDefn*(xs: CirruData, localDefs: Hashset[string], preprocess: FnPreprocess): CirruData =
   if xs.kind != crDataList:
     raiseEvalError("Expects a list", xs)
@@ -71,35 +47,6 @@ proc processDefn*(xs: CirruData, localDefs: Hashset[string], preprocess: FnPrepr
   # echo "DEBUG"
   # echo CirruData(kind: crDataList, listVal: ys)
   # echo CirruData(kind: crDataList, listVal: body)
-
-  for item in body:
-    ys = ys.append preprocess(item, newDefs)
-
-  return CirruData(kind: crDataList, listVal: ys)
-
-proc processFn*(xs: CirruData, localDefs: Hashset[string], preprocess: FnPreprocess): CirruData =
-  if xs.kind != crDataList:
-    raiseEvalError("Expects a list", xs)
-  if xs.len < 3:
-    raiseEvalError("Expects len >=3", xs)
-
-  var ys = xs.listVal.slice(0,2)
-  let args = xs[1]
-  let body = xs.listVal.slice(2, xs.len)
-
-  # echo "DEBUG"
-  # echo CirruData(kind: crDataList, listVal: ys)
-  # echo CirruData(kind: crDataList, listVal: body)
-
-  var newDefs = localDefs
-  if args.kind != crDataList:
-    raiseEvalError("Expects a list", args)
-
-  for item in args:
-    if item.kind != crDataSymbol:
-      raiseEvalError("Expects a symbol", item)
-    if item.symbolVal != "&":
-      newDefs.incl(item.symbolVal)
 
   for item in body:
     ys = ys.append preprocess(item, newDefs)

--- a/tests/snapshots/test-macro.cirru
+++ b/tests/snapshots/test-macro.cirru
@@ -90,19 +90,19 @@
 
             assert "|expand lambda" $ =
               macroexpand $ quote (\ + 2 %)
-              quote $ fn (%) (+ 2 %)
+              quote $ defn generated-fn (%) (+ 2 %)
 
             assert "|expand lambda" $ =
               macroexpand $ quote $ \ x
-              quote $ fn (%) (x)
+              quote $ defn generated-fn (%) (x)
 
             assert "|expand lambda" $ =
               macroexpand $ quote $ \ + x %
-              quote $ fn (%) (+ x %)
+              quote $ defn generated-fn (%) (+ x %)
 
             assert "|expand lambda" $ =
               macroexpand $ quote $ \ + x % %2
-              quote $ fn (% %2) (+ x % %2)
+              quote $ defn generated-fn (% %2) (+ x % %2)
 
         |main! $ quote
           defn main! ()

--- a/tests/snapshots/test-map.cirru
+++ b/tests/snapshots/test-map.cirru
@@ -68,6 +68,12 @@
                 vals $ {} (:a 1) (:b 2) (:c 2)
                 [] 2 1 2
 
+        |test-native-map-syntax $  quote
+          defn test-native-map-syntax ()
+            assert "|internally {} is a macro" $ =
+              macroexpand $ quote $ {} (:a 1)
+              quote $ &{} ([] :a 1)
+
         |log-title $ quote
           defn log-title (title)
             echo
@@ -79,6 +85,9 @@
 
             log-title "|Testing maps"
             test-maps
+
+            log-title "|Testing map syntax"
+            test-native-map-syntax
 
             echo "|Finished running test"
             do true

--- a/tests/snapshots/test.cirru
+++ b/tests/snapshots/test.cirru
@@ -136,74 +136,6 @@
               assert "|try case" $ &= (detect-x 2) "|two"
               assert "|try case" $ &= (detect-x 3) "|else"
 
-        |test-thread-macros $ quote
-          defn test-thread-macros ()
-            assert "|try -> macro" $ &=
-              macroexpand $ quote $ -> a b c
-              quote (c (b a))
-
-            assert "|try -> macro" $ &=
-              macroexpand $ quote $ -> a (b) c
-              quote (c (b a))
-
-            assert "|try -> macro" $ &=
-              macroexpand $ quote $ -> a (b c)
-              quote (b a c)
-
-            assert "|try -> macro" $ &=
-              macroexpand $ quote $ -> a (b c) (d e f)
-              quote (d (b a c) e f)
-
-            assert "|try ->> macro" $ &=
-              macroexpand $ quote $ ->> a b c
-              quote (c (b a))
-
-            assert "|try ->> macro" $ &=
-              macroexpand $ quote $ ->> a (b) c
-              quote (c (b a))
-
-            assert "|try ->> macro" $ &=
-              macroexpand $ quote $ ->> a (b c)
-              quote (b c a)
-
-            assert "|try ->> macro" $ &=
-              macroexpand $ quote $ ->> a (b c) (d e f)
-              quote (d e f (b c a))
-
-            assert "|contains-symbol?" $ contains-symbol?
-              quote $ add $ + 1 %
-              , '%
-
-            assert "|contains-symbol?" $ not $ contains-symbol?
-              quote $ add $ + 1 2
-              , '%
-
-            assert "|lambda" $ =
-              map (\ + 1 %) (range 3)
-              range 1 4
-            assert "|lambda" $ =
-              map-indexed (\ [] % (&str %2)) (range 3)
-              []
-                [] 0 |0
-                [] 1 |1
-                [] 2 |2
-
-            assert "|expand lambda" $ =
-              macroexpand $ quote (\ + 2 %)
-              quote $ fn (%) (+ 2 %)
-
-            assert "|expand lambda" $ =
-              macroexpand $ quote $ \ x
-              quote $ fn (%) (x)
-
-            assert "|expand lambda" $ =
-              macroexpand $ quote $ \ + x %
-              quote $ fn (%) (+ x %)
-
-            assert "|expand lambda" $ =
-              macroexpand $ quote $ \ + x % %2
-              quote $ fn (% %2) (+ x % %2)
-
         |test-compare $ quote
           defn test-compare ()
             assert "|find max" $ = 4 $ max $ [] 1 2 3 4
@@ -245,9 +177,6 @@
 
             log-title "|Testing cond/case"
             test-cond
-
-            log-title "|Testing thread macros"
-            test-thread-macros
 
             log-title "|Testing compare"
             test-compare


### PR DESCRIPTION
Now `{}` and `fn` are implemented with macros, so there's fewer syntax rules to handle during preprocess. Meanwhile it brings costs in performance since macro expanding is processed via runtime of `CirruData`.
