### PR TITLE
add -e to eval from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ nimble watch
 
 # just run once
 nimble once
+
+# demo of eval from CLI
+nimble e
 ```
 
 If you build `cr` with `nimble build`, just
@@ -58,6 +61,8 @@ If you build `cr` with `nimble build`, just
 cr compact.cirru # run and wath
 
 cr compact.cirru --once # run only once
+
+cr -e="echo $ range 100" # eval from CLI
 ```
 
 _Not ready for a release yet_

--- a/calcit_runner.nimble
+++ b/calcit_runner.nimble
@@ -34,3 +34,6 @@ task tg, "test gynienic macro":
 
 task ct, "Runs calcit tests":
   exec "nim c -r --hints:off --threads:on tests/run_calcit.nim"
+
+task e, "eval some code":
+  exec "nim compile --verbosity:0 --hints:off --threads:on -r src/cr -e='echo 1'"

--- a/example/calcit.cirru
+++ b/example/calcit.cirru
@@ -2399,6 +2399,9 @@
           :data $ {}
             |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1604812556876) (:text |ns)
             |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1604812556876) (:text |app.draw)
+            |r $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1604984347300)
+              :data $ {}
+                |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1604984347991) (:text |:require)
         :defs $ {}
           |try-redraw-canvas $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1604160771998)
             :data $ {}
@@ -2537,6 +2540,11 @@
               |x $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1604160801199)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1604247751080) (:text |try-redraw-canvas)
+              |t $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1604984283311)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1604984284307) (:text |echo)
+                  |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1604984285389) (:text "|\"init")
+                  |r $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1604984367412) (:text "|\"canvas")
           |*control-point $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1604812656306)
             :data $ {}
               |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1604812658872) (:text |defatom)

--- a/example/compact.cirru
+++ b/example/compact.cirru
@@ -277,7 +277,7 @@
       :proc $ quote ()
       :configs $ {}
     |app.draw $ {}
-      :ns $ quote (ns app.draw)
+      :ns $ quote (ns app.draw $ :require)
       :defs $ {}
         |try-redraw-canvas $ quote
           defn try-redraw-canvas ()
@@ -289,7 +289,7 @@
                 :stroke-color $ [] 200 90 80 1
               {} (:type :touch-area) (:x 100) (:y 100) (:radius 20) (:path "\"inc") (:events $ [] :touch-down)
         |try-canvas $ quote
-          defn try-canvas ()
+          defn try-canvas () (echo "\"init" "\"canvas")
             init-canvas $ {} (:title "\"DEMO") (:width 1200) (:height 800)
             try-redraw-canvas
         |*control-point $ quote

--- a/src/calcit_runner/data.nim
+++ b/src/calcit_runner/data.nim
@@ -139,7 +139,7 @@ proc `[]`*(xs: CirruData, fromTo: HSlice[int, BackwardsIndex]): seq[CirruData] =
   let toB =  xs.len - fromTo.b.int
   xs[fromA .. toB]
 
-proc parseLiteral*(token: string, ns: string, scope: Option[CirruDataScope]): CirruData =
+proc parseLiteral*(token: string, ns: string): CirruData =
   if token == "":
     raise newException(ValueError, "Unknown empty symbol")
 
@@ -165,13 +165,13 @@ proc parseLiteral*(token: string, ns: string, scope: Option[CirruDataScope]): Ci
   else:
     return CirruData(kind: crDataSymbol, symbolVal: token, ns: ns)
 
-proc toCirruData*(xs: CirruNode, ns: string, scope: Option[CirruDataScope]): CirruData =
+proc toCirruData*(xs: CirruNode, ns: string): CirruData =
   if xs.kind == cirruString:
-    parseLiteral(xs.text, ns, scope)
+    parseLiteral(xs.text, ns)
   else:
     var list = initTernaryTreeList[CirruData](@[])
     for x in xs:
-      list = list.append x.toCirruData(ns, scope)
+      list = list.append x.toCirruData(ns)
     CirruData(kind: crDataList, listVal: list)
 
 proc spreadArgs*(xs: seq[CirruData]): seq[CirruData] =

--- a/src/calcit_runner/gen_code.nim
+++ b/src/calcit_runner/gen_code.nim
@@ -1,7 +1,6 @@
 
 import macros
 import strformat
-import options
 import json
 import sequtils
 
@@ -11,7 +10,7 @@ import ./types
 import ./data
 
 proc toCirruData(x: string, ns: string): CirruData =
-  return parseLiteral(x, ns, none(CirruDataScope))
+  return parseLiteral(x, ns)
 
 proc toCirruData(x: int): CirruData =
   CirruData(kind: crDataNumber, numberVal: x.float)
@@ -52,7 +51,7 @@ proc toCirruCode*(v: JsonNode, ns: string): CirruData =
   of JBool:
     return CirruData(kind: crDataBool, boolVal: v.bval)
   of JString:
-    return parseLiteral(v.str, ns, none(CirruDataScope))
+    return parseLiteral(v.str, ns)
   of JInt:
     return CirruData(kind: crDataNumber, numberVal: v.num.float)
   of JFloat:
@@ -87,3 +86,14 @@ proc shortenCode*(code: string, n: int): string =
     code[0..<n] & "..."
   else:
     code
+
+proc generateMainCode*(code: CirruData, ns: string): CirruData =
+  CirruData(kind: crDataList, listVal: initTernaryTreeList(@[
+    CirruData(kind: crDataSymbol, symbolVal: "defn", ns: ns),
+    CirruData(kind: crDataSymbol, symbolVal: "main!", ns: ns),
+    CirruData(kind: crDataList, listVal: initTernaryTreeList[CirruData](@[])),
+    CirruData(kind: crDataList, listVal: initTernaryTreeList(@[
+      CirruData(kind: crDataSymbol, symbolVal: "echo", ns: ns),
+      code,
+    ])),
+  ]))

--- a/src/calcit_runner/gen_data.nim
+++ b/src/calcit_runner/gen_data.nim
@@ -70,4 +70,4 @@ proc toCirruData*(xs: CirruEdnValue, ns: string, scope: Option[CirruDataScope]):
     for key, value in xs.mapVal:
       ys[key.toCirruData(ns, scope)] = value.toCirruData(ns, scope)
     CirruData(kind: crDataMap, mapVal: initTernaryTreeMap(ys))
-  of crEdnQuotedCirru: xs.quotedVal.toCirruData(ns, scope)
+  of crEdnQuotedCirru: xs.quotedVal.toCirruData(ns)

--- a/src/calcit_runner/loader.nim
+++ b/src/calcit_runner/loader.nim
@@ -17,7 +17,7 @@ proc getSourceNode(v: CirruEdnValue, ns: string, scope: Option[CirruDataScope] =
     echo "current node: ", v
     raise newException(ValueError, "Unexpected quoted cirru node")
 
-  return v.quotedVal.toCirruData(ns, scope)
+  return v.quotedVal.toCirruData(ns)
 
 proc extractDefs(defs: CirruEdnValue, ns: string): Table[string, CirruData] =
   result = initTable[string, CirruData]()
@@ -232,3 +232,7 @@ proc extractNsInfo*(exprNode: CirruData): Table[string, ImportInfo] =
         dict[defName.symbolVal] = ImportInfo(kind: importDef, ns: nsPart.symbolVal, def: defName.symbolVal)
 
   return dict
+
+proc parseEvalMain*(code: string, ns: string): CirruData =
+  let tree = parseCirru(code)
+  tree.toCirruData(ns)

--- a/src/cr.nim
+++ b/src/cr.nim
@@ -11,7 +11,9 @@ import ./calcit_runner/canvas
 import ./calcit_runner/watcher
 import ./calcit_runner/errors
 
-var runOnce* = false
+var runOnce = false
+var evalOnce = false
+var evalOnceCode: string
 
 registerCoreProc("init-canvas", nativeInitCanvas)
 registerCoreProc("draw-canvas", nativeDrawCanvas)
@@ -64,6 +66,10 @@ while true:
       if cliArgs.val == "" or cliArgs.val == "true":
         runOnce = true
         dimEcho "Runner: watching mode disabled."
+    if cliArgs.key == "e":
+      evalOnce = true
+      evalOnceCode = cliArgs.val
+      break
   of cmdLongOption:
     if cliArgs.key == "once":
       if cliArgs.val == "" or cliArgs.val == "true":
@@ -74,8 +80,12 @@ while true:
     incrementFile = cliArgs.key.replace("compact", ".compact-inc")
     dimEcho "Runner: specifying files", snapshotFile, incrementFile
 
+if evalOnce:
+  discard evalSnippet(evalOnceCode)
+elif runOnce:
   discard runProgram(snapshotFile)
-
-  if not runOnce:
-    setControlCHook(handleControl)
-    watchFile(snapshotFile, incrementFile)
+else:
+  discard runProgram(snapshotFile)
+  # watch mode by default
+  setControlCHook(handleControl)
+  watchFile(snapshotFile, incrementFile)


### PR DESCRIPTION
```bash
=>> nimble build --threads:on
=>> ./out/cr -e="section-by 4 $ range 20"
((0 1 2 3) (4 5 6 7) (8 9 10 11) (12 13 14 15) (16 17 18 19))
```

internally it generates from template and eval:

```cirru
defn main! ()
  echo $ section-by 4 $ range 20
```
