### PR TITLE
add set-trace-fn! for debugging

### DIFF
--- a/src/calcit_runner/core_func.nim
+++ b/src/calcit_runner/core_func.nim
@@ -20,6 +20,7 @@ import ./gen_data
 import ./gen_code
 import ./eval_util
 import ./atoms
+import ./stack
 
 # init generator for rand
 randomize()
@@ -952,6 +953,15 @@ proc nativeTrim(args: seq[CirruData], interpret: FnInterpret, scope: CirruDataSc
       spaceChars.incl(x)
   return CirruData(kind: crDataString, stringVal: origin.stringVal.strip(chars = spaceChars))
 
+proc nativeSetTraceFnBang(args: seq[CirruData], interpret: FnInterpret, scope: CirruDataScope, ns: string): CirruData =
+  if args.len != 2: raiseEvalError("set-trace-fn! expects 2 arguments", args)
+  let nsPart = args[0]
+  if nsPart.kind != crDataString: raiseEvalError("Expects string for ns", args)
+  let defPart = args[1]
+  if defPart.kind != crDataString: raiseEvalError("Expects string for ns", args)
+  setTraceFn(nsPart.stringVal, defPart.stringVal)
+  CirruData(kind: crDataNil)
+
 # injecting functions to calcit.core directly
 proc loadCoreDefs*(programData: var Table[string, ProgramFile], interpret: FnInterpret): void =
   programData[coreNs].defs["&+"] = CirruData(kind: crDataProc, procVal: nativeAdd)
@@ -1033,3 +1043,4 @@ proc loadCoreDefs*(programData: var Table[string, ProgramFile], interpret: FnInt
   programData[coreNs].defs["str-find"] = CirruData(kind: crDataProc, procVal: nativeStrFind)
   programData[coreNs].defs["parse-float"] = CirruData(kind: crDataProc, procVal: nativeParseFloat)
   programData[coreNs].defs["trim"] = CirruData(kind: crDataProc, procVal: nativeTrim)
+  programData[coreNs].defs["set-trace-fn!"] = CirruData(kind: crDataProc, procVal: nativeSetTraceFnBang)

--- a/src/calcit_runner/core_syntax.nim
+++ b/src/calcit_runner/core_syntax.nim
@@ -57,7 +57,7 @@ proc nativeDefn(exprList: seq[CirruData], interpret: FnInterpret, scope: CirruDa
   if fnName.kind != crDataSymbol: raiseEvalError("Expects fnName to be string", exprList)
   let argsList = exprList[1]
   if argsList.kind != crDataList: raiseEvalError("Expects args to be list", exprList)
-  return CirruData(kind: crDataFn, fnName: fnName.symbolVal, fnArgs: argsList.listVal, fnCode: exprList[2..^1], fnScope: scope)
+  return CirruData(kind: crDataFn, fnNs: ns, fnName: fnName.symbolVal, fnArgs: argsList.listVal, fnCode: exprList[2..^1], fnScope: scope)
 
 proc nativeLet(exprList: seq[CirruData], interpret: FnInterpret, scope: CirruDataScope, ns: string): CirruData =
   var letScope = scope

--- a/src/calcit_runner/evaluate.nim
+++ b/src/calcit_runner/evaluate.nim
@@ -118,13 +118,23 @@ proc interpret*(xs: CirruData, scope: CirruDataScope, ns: string): CirruData =
     return ret
 
   of crDataFn:
+    let traceThis = matchesTraceFn(value.fnNs, value.fnName)
+    let fnPath =  value.fnNs & "/" & value.fnName
     let args = spreadFuncArgs(xs[1..^1], interpret, scope, ns)
+
+    if traceThis:
+      echo getTraceIndentation(), value.fnName, " -> ", CirruData(kind: crDataList, listVal: initTernaryTreeList(args))
+      traceStackSize = traceStackSize + 1
 
     # echo "HEAD: ", head, " ", xs
     pushDefStack(head, CirruData(kind: crDataList, listVal: initTernaryTreeList(value.fnCode)), args)
     # echo "calling: ", CirruData(kind: crDataList, listVal: initTernaryTreeList(args)), " ", xs
 
     let ret = evaluteFnData(value, args, interpret, ns)
+
+    if traceThis:
+      traceStackSize = traceStackSize - 1
+      echo getTraceIndentation(), "<- ", ret
 
     popDefStack()
     return ret

--- a/src/calcit_runner/stack.nim
+++ b/src/calcit_runner/stack.nim
@@ -1,5 +1,6 @@
 
 import lists
+import strutils
 
 import ternary_tree
 
@@ -40,3 +41,17 @@ proc showStack*(): void =
     echo item.ns, "/", item.def
     dimEcho $item.code
     dimEcho "args: ", $CirruData(kind: crDataList, listVal: initTernaryTreeList(item.args))
+
+var traceFnNs: string
+var traceFnName: string
+var traceStackSize* = 0
+
+proc matchesTraceFn*(ns: string, def: string): bool =
+  traceFnNs == ns and traceFnName == def
+
+proc setTraceFn*(ns: string, def: string) =
+  traceFnNs = ns
+  traceFnName = def
+
+proc getTraceIndentation*(): string =
+  repeat("  ", traceStackSize)

--- a/tests/run_calcit.nim
+++ b/tests/run_calcit.nim
@@ -2,4 +2,5 @@
 import calcit_runner
 
 # discard runProgram("tests/snapshots/test.cirru")
-discard runProgram("tests/snapshots/test-cond.cirru")
+# discard runProgram("tests/snapshots/test-cond.cirru")
+discard runProgram("tests/snapshots/test-recursion.cirru")

--- a/tests/snapshots/test-recursion.cirru
+++ b/tests/snapshots/test-recursion.cirru
@@ -44,6 +44,9 @@
             log-title "|Testing hole series"
             test-hole-series
 
+            ; set-trace-fn! |app.main |hole-series
+            ; echo (hole-series 100)
+
             do true
 
       :proc $ quote ()


### PR DESCRIPTION
`set-trace-fn!` is a function for configuring internal state in interpreter and print arguments and results during running, for example:

```cirru
set-trace-fn! |app.main |hole-series
echo (hole-series 100)
```

```text
hole-series -> (100)
  hole-series -> (33)
    hole-series -> (11)
      hole-series -> (4)
        hole-series -> (1)
        <- 0
        hole-series -> (2)
        <- 1
      <- 1
      hole-series -> (3)
        hole-series -> (1)
        <- 0
      <- 0
    <- 2
  <- 6
  hole-series -> (34)
    hole-series -> (11)
      hole-series -> (4)
        hole-series -> (1)
        <- 0
        hole-series -> (2)
        <- 1
      <- 1
      hole-series -> (3)
        hole-series -> (1)
        <- 0
      <- 0
    <- 2
    hole-series -> (12)
      hole-series -> (4)
        hole-series -> (1)
        <- 0
        hole-series -> (2)
        <- 1
      <- 1
    <- 3
  <- 7
<- 19
```