### PR TITLE
Refactored let to implement let->

### DIFF
--- a/src/calcit_runner/core_abstract.nim
+++ b/src/calcit_runner/core_abstract.nim
@@ -583,6 +583,21 @@ proc loadCoreFuncs*(programCode: var Table[string, FileSource]) =
       ["&=", ["&-", [count, x], [count, y]], ["str-find", x, y]]]
   , coreNs)
 
+  let codeLoop = genCirru(
+    [defmacro, loop, [pairs, "&", body],
+      ["assert", "|loops requires pairs", ["list?", pairs]],
+      ["assert", "|loops requires pairs in pairs",
+        ["every?", [defn, "detect-pairs", [x], ["&and", ["list?", x], ["=", 2, [count, x]]]], pairs]],
+      ["let", [
+          [args, [map, first, pairs]],
+          [values, [map, last, pairs]],
+        ],
+        ["assert", "|loop requires symbols in pairs", ["every?", "symbol?", args]],
+        ["quote-replace", [apply,
+                            [defn, "generated-loop", ["~", args], ["~@", body]],
+                            ["[]", ["~@", values]]]]]]
+  , coreNs)
+
   # programCode[coreNs].defs["foldl"] = codeFoldl
   programCode[coreNs].defs["unless"] = codeUnless
   programCode[coreNs].defs["&<="] = codeNativeLittlerEqual
@@ -667,3 +682,4 @@ proc loadCoreFuncs*(programCode: var Table[string, FileSource]) =
   programCode[coreNs].defs["inc"] = codeInc
   programCode[coreNs].defs["starts-with?"] = codeStartsWithQuestion
   programCode[coreNs].defs["ends-with?"] = codeEndsWithQuestion
+  programCode[coreNs].defs["loop"] = codeLoop # TODO

--- a/src/calcit_runner/core_abstract.nim
+++ b/src/calcit_runner/core_abstract.nim
@@ -598,6 +598,16 @@ proc loadCoreFuncs*(programCode: var Table[string, FileSource]) =
                             ["[]", ["~@", values]]]]]]
   , coreNs)
 
+  let codeLet = genCirru(
+    [defmacro, "let", [pairs, "&", body],
+      ["if", ["&=", 1, [count, pairs]],
+        ["quote-replace", ["&let", ["~", [first, pairs]], ["~@", body]]],
+        ["if", ["empty?", pairs],
+          ["quote-replace", ["do", ["~@", body]]],
+          ["quote-replace", ["&let", ["~", [first, pairs]],
+                                     ["let", ["~", [rest, pairs]], ["~@", body]]]]]]]
+  , coreNs)
+
   # programCode[coreNs].defs["foldl"] = codeFoldl
   programCode[coreNs].defs["unless"] = codeUnless
   programCode[coreNs].defs["&<="] = codeNativeLittlerEqual
@@ -682,4 +692,5 @@ proc loadCoreFuncs*(programCode: var Table[string, FileSource]) =
   programCode[coreNs].defs["inc"] = codeInc
   programCode[coreNs].defs["starts-with?"] = codeStartsWithQuestion
   programCode[coreNs].defs["ends-with?"] = codeEndsWithQuestion
-  programCode[coreNs].defs["loop"] = codeLoop # TODO
+  programCode[coreNs].defs["loop"] = codeLoop
+  programCode[coreNs].defs["let"] = codeLet

--- a/src/calcit_runner/core_abstract.nim
+++ b/src/calcit_runner/core_abstract.nim
@@ -609,6 +609,20 @@ proc loadCoreFuncs*(programCode: var Table[string, FileSource]) =
                                      ["let", ["~", [rest, pairs]], ["~@", body]]]]]]]
   , coreNs)
 
+  let codeLetThread = genCirru(
+    [defmacro, "let->", ["&", body],
+      ["if", ["empty?", body], [quote, "nil"],
+        ["if", ["&=", 1, [count, body]],
+          ["do",
+            ["assert", "|unexpected let in last item of body", ["/=", "'let", [first, body]]],
+            [first, body]],
+          ["&let", [target, [first, body]],
+            ["if", ["&=", "'let", [first, target]],
+              ["quote-replace", ["&let", ["~", [rest, [first, body]]], ["let->", ["~@", [rest, body]]]]],
+              ["quote-replace", ["do", ["~", [first, body]], ["let->", ["~@", [rest, body]]]]],
+              ]]]]]
+  , coreNs)
+
   # programCode[coreNs].defs["foldl"] = codeFoldl
   programCode[coreNs].defs["unless"] = codeUnless
   programCode[coreNs].defs["&<="] = codeNativeLittlerEqual
@@ -695,3 +709,4 @@ proc loadCoreFuncs*(programCode: var Table[string, FileSource]) =
   programCode[coreNs].defs["ends-with?"] = codeEndsWithQuestion
   programCode[coreNs].defs["loop"] = codeLoop
   programCode[coreNs].defs["let"] = codeLet
+  programCode[coreNs].defs["let->"] = codeLetThread

--- a/src/calcit_runner/core_syntax.nim
+++ b/src/calcit_runner/core_syntax.nim
@@ -63,20 +63,17 @@ proc nativeLet(exprList: seq[CirruData], interpret: FnInterpret, scope: CirruDat
   var letScope = scope
   if exprList.len < 1:
     raiseEvalError("No enough code for let, too short", exprList)
-  let pairs = exprList[0]
+  let pair = exprList[0]
   let body = exprList[1..^1]
-  if pairs.kind != crDataList:
-    raiseEvalError("Expect bindings in a list", pairs)
-  for pair in pairs:
-    if pair.kind != crDataList:
-      raiseEvalError("Expect binding in a list", pair)
-    if pair.len != 2:
-      raiseEvalError("Expect binding in length 2", pair)
-    let name = pair[0]
-    let value = pair[1]
-    if name.kind != crDataSymbol:
-      raiseEvalError("Expecting binding name in string", name)
-    letScope = letScope.assoc(name.symbolVal, interpret(value, letScope, ns))
+  if pair.kind != crDataList:
+    raiseEvalError("Expect binding in a list", pair)
+  if pair.len != 2:
+    raiseEvalError("Expect binding in length 2", pair)
+  let name = pair[0]
+  let value = pair[1]
+  if name.kind != crDataSymbol:
+    raiseEvalError("Expecting binding name in string", name)
+  letScope = letScope.assoc(name.symbolVal, interpret(value, letScope, ns))
   result = CirruData(kind: crDataNil)
   for child in body:
     result = interpret(child, letScope, ns)
@@ -198,6 +195,6 @@ proc loadCoreSyntax*(programData: var Table[string, ProgramFile], interpret: FnI
   programData[coreNs].defs["do"] = CirruData(kind: crDataSyntax, syntaxVal: nativeDo)
   programData[coreNs].defs["if"] = CirruData(kind: crDataSyntax, syntaxVal: nativeIf)
   programData[coreNs].defs["defn"] = CirruData(kind: crDataSyntax, syntaxVal: nativeDefn)
-  programData[coreNs].defs["let"] = CirruData(kind: crDataSyntax, syntaxVal: nativeLet)
+  programData[coreNs].defs["&let"] = CirruData(kind: crDataSyntax, syntaxVal: nativeLet)
   programData[coreNs].defs["quote"] = CirruData(kind: crDataSyntax, syntaxVal: nativeQuote)
   programData[coreNs].defs["defatom"] = CirruData(kind: crDataSyntax, syntaxVal: nativeDefAtom)

--- a/src/calcit_runner/evaluate.nim
+++ b/src/calcit_runner/evaluate.nim
@@ -192,15 +192,15 @@ proc preprocess(code: CirruData, localDefs: Hashset[string], ns: string): CirruD
   # echo "\nPreprocess: ", code
   case code.kind
   of crDataSymbol:
+    if code.dynamic:
+      return code
+
     if localDefs.contains(code.symbolVal):
       return code
     elif code.symbolVal == "&" or code.symbolVal == "~" or code.symbolVal == "~@":
       return code
     else:
       var sym = code
-
-      if sym.dynamic:
-        return sym
 
       let coreDefs = programData[coreNs].defs
       if coreDefs.contains(sym.symbolVal):

--- a/src/calcit_runner/evaluate.nim
+++ b/src/calcit_runner/evaluate.nim
@@ -286,8 +286,8 @@ proc preprocess(code: CirruData, localDefs: Hashset[string], ns: string): CirruD
           return code
         of "defn", "defmacro":
           return processDefn(code, localDefs, preprocessHelper, ns)
-        of "let":
-          return processBinding(code, localDefs, preprocessHelper, ns)
+        of "&let":
+          return processNativeLet(code, localDefs, preprocessHelper, ns)
         of "[]", "if", "assert", "do", "quote-replace":
           return processAll(code, localDefs, preprocessHelper, ns)
         of "quote":

--- a/src/calcit_runner/evaluate.nim
+++ b/src/calcit_runner/evaluate.nim
@@ -286,7 +286,7 @@ proc preprocess(code: CirruData, localDefs: Hashset[string], ns: string): CirruD
           return code
         of "defn", "defmacro":
           return processDefn(code, localDefs, preprocessHelper, ns)
-        of "let", "loop":
+        of "let":
           return processBinding(code, localDefs, preprocessHelper, ns)
         of "[]", "if", "assert", "do", "quote-replace":
           return processAll(code, localDefs, preprocessHelper, ns)

--- a/tests/snapshots/test-macro.cirru
+++ b/tests/snapshots/test-macro.cirru
@@ -116,6 +116,14 @@
               macroexpand $ quote $ \ + x % %2
               quote $ defn generated-fn (% %2) (+ x % %2)
 
+        |test-let $ quote
+          fn ()
+            assert= 3
+              let->
+                let a 1
+                let b 2
+                + b a
+
         |main! $ quote
           defn main! ()
             log-title "|Testing cond"
@@ -129,6 +137,9 @@
 
             log-title "|Testing thread macros"
             test-thread-macros
+
+            log-title "|Testing let thread"
+            test-let
 
             do true
 

--- a/tests/snapshots/test-recursion.cirru
+++ b/tests/snapshots/test-recursion.cirru
@@ -39,6 +39,20 @@
             assert "|hole series numbers" $ = (map hole-series (range 1 20))
               [] 0 1 0 1 2 3 2 1 0 1 2 3 4 5 6 7 8 9 8
 
+        |test-loop $ quote
+          fn ()
+            echo $ apply
+              defn add-range (acc from to)
+                if (> from to) acc
+                  recur (&+ acc from) (inc from) to
+              [] 0 1 10
+            echo $ loop
+                acc 0
+                from 1
+                to 10
+              if (> from to) acc
+                recur (&+ acc from) (inc from) to
+
         |main! $ quote
           defn main! ()
             log-title "|Testing hole series"
@@ -46,6 +60,9 @@
 
             ; set-trace-fn! |app.main |hole-series
             ; echo (hole-series 100)
+
+            log-title "|Testing loop"
+            test-loop
 
             do true
 


### PR DESCRIPTION
Simplified core implementation of `let` a bit, turning it into a macro of `&let`, which made it possible for implement `let->`:

```cirru
let
    a 1
    b a
  echo a
  echo $ + a b
```

```cirru
&let (a 1)
  &let (b 2)
    echo a
    echo $ + a b
```

```cirru
let->
  let a 1
  let b 2
  echo a
  echo $ + a b
```
