### PR TITLE
Reduce core syntax

### DIFF
--- a/calcit_runner.nimble
+++ b/calcit_runner.nimble
@@ -24,7 +24,7 @@ task once, "run once":
   exec "nim compile --verbosity:0 --hints:off --threads:on -r src/cr --once example/compact.cirru"
 
 task perf, "run with perf":
-  exec "nim compile --verbosity:0 --profiler:on --stackTrace:on --hints:off --threads:on -r tests/prof --once tests/snapshots/fibo.cirru"
+  exec "nim compile --verbosity:0 --profiler:on --stackTrace:on --hints:off -r tests/prof"
 
 task t, "Runs the test suite":
   exec "nim c -r --hints:off --threads:on tests/test_expr.nim"

--- a/example/compact.cirru
+++ b/example/compact.cirru
@@ -33,7 +33,7 @@
               echo "\"reloaded... 7" a
         |hole-series $ quote
           defn hole-series (x)
-            if (&<= x 0) (raise-at "\"unexpected small number" x)
+            if (&<= x 0) (raise "\"unexpected small number")
               if (&= x 1) (, 0)
                 if (&= x 2) (, 1)
                   let

--- a/src/calcit_runner/core_abstract.nim
+++ b/src/calcit_runner/core_abstract.nim
@@ -449,7 +449,7 @@ proc loadCoreFuncs*(programCode: var Table[string, FileSource]) =
          ["if", ["has-index?", x, k], [assoc, x, k, [f, [get, x, k]]], x]],
         [["map?", x],
          ["if", ["contains?", x, k], [assoc, x, k, [f, [get, x, k]]], x]],
-        [true, ["raise-at", "|Cannot update key on item:", x]]]]
+        [true, ["raise", [str, "|Cannot update key on item: ", x]]]]]
   , coreNs)
 
   let codeGroupBy = genCirru(
@@ -535,7 +535,7 @@ proc loadCoreFuncs*(programCode: var Table[string, FileSource]) =
                           ["echo", "|       ", [quote, ["~", a]]],
                           ["echo", "|Got:   ", vb],
                           ["echo", "|       ", [quote, ["~", b]]],
-                          ["raise-at", "|Not equal!", ["~", b]]],
+                          ["raise", "|Not equal!"]],
                         "nil"]]]]
   , coreNs)
 
@@ -629,6 +629,14 @@ proc loadCoreFuncs*(programCode: var Table[string, FileSource]) =
         ["quote-replace", ["&[]", ["~@", xs]]]]]
   , coreNs)
 
+  let codeAssert = genCirru(
+    [defmacro, "assert", [message, xs],
+      ["quote-replace", ["if", ["~", xs], "nil",
+                               ["do",
+                                ["echo", "|Failed assertion:", [quote, ["~", xs]]],
+                                ["raise", ["~", message]]]]]]
+  , coreNs)
+
   # programCode[coreNs].defs["foldl"] = codeFoldl
   programCode[coreNs].defs["unless"] = codeUnless
   programCode[coreNs].defs["&<="] = codeNativeLittlerEqual
@@ -717,3 +725,4 @@ proc loadCoreFuncs*(programCode: var Table[string, FileSource]) =
   programCode[coreNs].defs["let"] = codeLet
   programCode[coreNs].defs["let->"] = codeLetThread
   programCode[coreNs].defs["[]"] = codeList
+  programCode[coreNs].defs["assert"] = codeAssert

--- a/src/calcit_runner/core_abstract.nim
+++ b/src/calcit_runner/core_abstract.nim
@@ -152,7 +152,7 @@ proc loadCoreFuncs*(programCode: var Table[string, FileSource]) =
       ["foldl",
         ["fn", ["acc", "x"],
           ["append", "acc", ["f", "x"]]],
-        "xs", ["[]"]]]
+        "xs", ["&[]"]]]
   , coreNs)
 
   let codeTake = genCirru(
@@ -243,9 +243,9 @@ proc loadCoreFuncs*(programCode: var Table[string, FileSource]) =
       ["if", ["empty?", "xs"], ["quote-replace", ["~", "base"]],
         ["&let", ["x0", ["first", "xs"]],
           ["if", ["list?", "x0"],
-            ["recur", ["&concat", ["[]", ["first", "x0"], "base"], ["rest", "x0"]],
+            ["recur", ["&concat", ["&[]", ["first", "x0"], "base"], ["rest", "x0"]],
                       "&", ["rest", "xs"]],
-            ["recur", ["[]", "x0", "base"], "&", ["rest", "xs"]]]]]]
+            ["recur", ["&[]", "x0", "base"], "&", ["rest", "xs"]]]]]]
   , coreNs)
 
   let codeThreadLast = genCirru(
@@ -254,7 +254,7 @@ proc loadCoreFuncs*(programCode: var Table[string, FileSource]) =
         ["&let", ["x0", ["first", "xs"]],
           ["if", ["list?", "x0"],
             ["recur", ["append", "x0", "base"], "&", ["rest", "xs"]],
-            ["recur", ["[]", "x0", "base"], "&", ["rest", "xs"]]]]]]
+            ["recur", ["&[]", "x0", "base"], "&", ["rest", "xs"]]]]]]
   , coreNs)
 
   let codeCond = genCirru(
@@ -357,7 +357,7 @@ proc loadCoreFuncs*(programCode: var Table[string, FileSource]) =
   let codeMapIndexed = genCirru(
     [defn, "map-indexed", [f, xs],
       [loop,
-        [[acc, ["[]"]], [idx, 0], [ys, xs]],
+        [[acc, ["&[]"]], [idx, 0], [ys, xs]],
         ["if", ["empty?", ys], acc,
              [recur, [append, acc, [f, idx, [first, ys]]],
                      ["&+", idx, 1],
@@ -372,7 +372,7 @@ proc loadCoreFuncs*(programCode: var Table[string, FileSource]) =
                   [append, acc, x],
                   acc]],
         xs,
-        ["[]"]]]
+        ["&[]"]]]
   , coreNs)
 
   let codeFilterNot = genCirru(
@@ -383,7 +383,7 @@ proc loadCoreFuncs*(programCode: var Table[string, FileSource]) =
                   [append, acc, x],
                   acc]],
         xs,
-        ["[]"]]]
+        ["&[]"]]]
   , coreNs)
 
   let codePairMap = genCirru(
@@ -462,7 +462,7 @@ proc loadCoreFuncs*(programCode: var Table[string, FileSource]) =
                      [key, [f, x0]]],
                     [recur, ["if", ["contains?", acc, key],
                         [update, acc, key, ["\\", append, "%", x0]],
-                        [assoc, acc, key, ["[]", x0]]], [rest, xs]]]]]
+                        [assoc, acc, key, ["&[]", x0]]], [rest, xs]]]]]
       ]
   , coreNs)
 
@@ -492,7 +492,7 @@ proc loadCoreFuncs*(programCode: var Table[string, FileSource]) =
 
   let codeSectionBy = genCirru(
     [defn, "section-by", [n, xs0],
-      [loop, [[acc, ["[]"]], [xs, xs0]],
+      [loop, [[acc, ["&[]"]], [xs, xs0]],
         ["if", ["&<=", [count, xs], n],
           [append, acc, xs],
           [recur, [append, acc, [take, n, xs]], [drop, n, xs]]]]]
@@ -507,14 +507,14 @@ proc loadCoreFuncs*(programCode: var Table[string, FileSource]) =
   let codeListList = genCirru(
     [defmacro, "[][]", ["&", xs],
       ["&let",
-        [items, [map, [fn, [x], ["quote-replace", ["[]", ["~@", x]]]],
+        [items, [map, [fn, [x], ["quote-replace", ["&[]", ["~@", x]]]],
                 xs]],
-        ["quote-replace", ["[]", ["~@", items]]]]]
+        ["quote-replace", ["&[]", ["~@", items]]]]]
     , coreNs)
 
   let codeMapSyntax = genCirru(
     [defmacro, "{}", ["&", xs],
-      ["&let", [ys, [map, [fn, [x], ["quote-replace", ["[]", ["~@", x]]]], xs]],
+      ["&let", [ys, [map, [fn, [x], ["quote-replace", ["&[]", ["~@", x]]]], xs]],
         ["quote-replace", ["&{}", ["~@", ys]]]]]
   , coreNs)
 
@@ -595,7 +595,7 @@ proc loadCoreFuncs*(programCode: var Table[string, FileSource]) =
         ["assert", "|loop requires symbols in pairs", ["every?", "symbol?", args]],
         ["quote-replace", [apply,
                             [defn, "generated-loop", ["~", args], ["~@", body]],
-                            ["[]", ["~@", values]]]]]]
+                            ["&[]", ["~@", values]]]]]]
   , coreNs)
 
   let codeLet = genCirru(
@@ -621,6 +621,12 @@ proc loadCoreFuncs*(programCode: var Table[string, FileSource]) =
               ["quote-replace", ["&let", ["~", [rest, [first, body]]], ["let->", ["~@", [rest, body]]]]],
               ["quote-replace", ["do", ["~", [first, body]], ["let->", ["~@", [rest, body]]]]],
               ]]]]]
+  , coreNs)
+
+  let codeList = genCirru(
+    [defmacro, "[]", ["&", body],
+      ["&let", [xs, [filter, [fn, [x], ["/=", x, "',"]], body]],
+        ["quote-replace", ["&[]", ["~@", xs]]]]]
   , coreNs)
 
   # programCode[coreNs].defs["foldl"] = codeFoldl
@@ -710,3 +716,4 @@ proc loadCoreFuncs*(programCode: var Table[string, FileSource]) =
   programCode[coreNs].defs["loop"] = codeLoop
   programCode[coreNs].defs["let"] = codeLet
   programCode[coreNs].defs["let->"] = codeLetThread
+  programCode[coreNs].defs["[]"] = codeList

--- a/src/calcit_runner/core_func.nim
+++ b/src/calcit_runner/core_func.nim
@@ -165,13 +165,12 @@ proc nativeRest(args: seq[CirruData], interpret: FnInterpret, scope: CirruDataSc
   else:
     raiseEvalError(fmt"Cannot rest from data of this type: {a.kind}", a)
 
-proc nativeRaiseAt(args: seq[CirruData], interpret: FnInterpret, scope: CirruDataScope, ns: string): CirruData =
-  if args.len != 2: coreFnError("Expected 2 arguments in native raise-at")
+proc nativeRaise(args: seq[CirruData], interpret: FnInterpret, scope: CirruDataScope, ns: string): CirruData =
+  if args.len != 1: coreFnError("Expected 1 argument1 in native raise")
   let a = args[0]
-  let b = args[1]
   if a.kind != crDataString:
     raiseEvalError("Expect message in string", a)
-  raiseEvalError(a.stringVal, b)
+  raiseEvalError(a.stringVal, args)
 
 proc nativeTypeOf(args: seq[CirruData], interpret: FnInterpret, scope: CirruDataScope, ns: string): CirruData =
   if args.len != 1: coreFnError("type gets 1 argument")
@@ -981,7 +980,7 @@ proc loadCoreDefs*(programData: var Table[string, ProgramFile], interpret: FnInt
   programData[coreNs].defs["count"] = CirruData(kind: crDataProc, procVal: nativeCount)
   programData[coreNs].defs["get"] = CirruData(kind: crDataProc, procVal: nativeGet)
   programData[coreNs].defs["rest"] = CirruData(kind: crDataProc, procVal: nativeRest)
-  programData[coreNs].defs["raise-at"] = CirruData(kind: crDataProc, procVal: nativeRaiseAt)
+  programData[coreNs].defs["raise"] = CirruData(kind: crDataProc, procVal: nativeRaise)
   programData[coreNs].defs["type-of"] = CirruData(kind: crDataProc, procVal: nativeTypeOf)
   programData[coreNs].defs["read-file"] = CirruData(kind: crDataProc, procVal: nativeReadFile)
   programData[coreNs].defs["write-file"] = CirruData(kind: crDataProc, procVal: nativeWriteFile)

--- a/src/calcit_runner/core_func.nim
+++ b/src/calcit_runner/core_func.nim
@@ -962,6 +962,9 @@ proc nativeSetTraceFnBang(args: seq[CirruData], interpret: FnInterpret, scope: C
   setTraceFn(nsPart.stringVal, defPart.stringVal)
   CirruData(kind: crDataNil)
 
+proc nativeList(args: seq[CirruData], interpret: FnInterpret, scope: CirruDataScope, ns: string): CirruData =
+  CirruData(kind: crDataList, listVal: initTernaryTreeList(args))
+
 # injecting functions to calcit.core directly
 proc loadCoreDefs*(programData: var Table[string, ProgramFile], interpret: FnInterpret): void =
   programData[coreNs].defs["&+"] = CirruData(kind: crDataProc, procVal: nativeAdd)
@@ -1044,3 +1047,4 @@ proc loadCoreDefs*(programData: var Table[string, ProgramFile], interpret: FnInt
   programData[coreNs].defs["parse-float"] = CirruData(kind: crDataProc, procVal: nativeParseFloat)
   programData[coreNs].defs["trim"] = CirruData(kind: crDataProc, procVal: nativeTrim)
   programData[coreNs].defs["set-trace-fn!"] = CirruData(kind: crDataProc, procVal: nativeSetTraceFnBang)
+  programData[coreNs].defs["&[]"] = CirruData(kind: crDataProc, procVal: nativeList)

--- a/src/calcit_runner/core_syntax.nim
+++ b/src/calcit_runner/core_syntax.nim
@@ -13,15 +13,6 @@ import ./errors
 import ./gen_code
 import ./atoms
 
-proc nativeList(exprList: seq[CirruData], interpret: FnInterpret, scope: CirruDataScope, ns: string): CirruData =
-  var args = initTernaryTreeList[CirruData](@[])
-  for node in exprList:
-    # commas in body are considered as nothing
-    if node.kind == crDataSymbol and node.symbolVal == ",":
-      continue
-    args = args.append interpret(node, scope, ns)
-  return CirruData(kind: crDataList, listVal: args)
-
 proc nativeIf*(exprList: seq[CirruData], interpret: FnInterpret, scope: CirruDataScope, ns: string): CirruData =
   if (exprList.len < 2):
     raiseEvalError(fmt"No arguments for if", exprList)
@@ -187,7 +178,6 @@ proc nativeDefAtom(exprList: seq[CirruData], interpret: FnInterpret, scope: Cirr
   CirruData(kind: crDataAtom, atomNs: name.ns, atomDef: name.symbolVal)
 
 proc loadCoreSyntax*(programData: var Table[string, ProgramFile], interpret: FnInterpret) =
-  programData[coreNs].defs["[]"] = CirruData(kind: crDataSyntax, syntaxVal: nativeList)
   programData[coreNs].defs["assert"] = CirruData(kind: crDataSyntax, syntaxVal: nativeAssert)
   programData[coreNs].defs["quote-replace"] = CirruData(kind: crDataSyntax, syntaxVal: nativeQuoteReplace)
   programData[coreNs].defs["defmacro"] = CirruData(kind: crDataSyntax, syntaxVal: nativeDefMacro)

--- a/src/calcit_runner/core_syntax.nim
+++ b/src/calcit_runner/core_syntax.nim
@@ -154,18 +154,6 @@ proc nativeDefMacro(exprList: seq[CirruData], interpret: FnInterpret, scope: Cir
   if argsList.kind != crDataList: raiseEvalError("Expects macro args to be a list", exprList)
   return CirruData(kind: crDataMacro, macroName: macroName.symbolVal, macroArgs: argsList.listVal, macroCode: exprList[2..^1])
 
-proc nativeAssert(exprList: seq[CirruData], interpret: FnInterpret, scope: CirruDataScope, ns: string): CirruData =
-  if exprList.len != 2:
-    raiseEvalError("assert expects 2 arguments", exprList)
-  let message = interpret(exprList[0], scope, ns)
-  if message.kind != crDataString:
-    raiseEvalError("Expected assert message in string", exprList[0])
-  let target = interpret(exprList[1], scope, ns)
-  if target.kind != crDataBool:
-    raiseEvalError("Expected assert target in bool", exprList[1])
-  if not target.boolVal:
-    raiseEvalError(message.stringVal, exprList)
-
 proc nativeDefAtom(exprList: seq[CirruData], interpret: FnInterpret, scope: CirruDataScope, ns: string): CirruData =
   if exprList.len != 2:
     raiseEvalError("assert expects 2 arguments", exprList)
@@ -178,7 +166,6 @@ proc nativeDefAtom(exprList: seq[CirruData], interpret: FnInterpret, scope: Cirr
   CirruData(kind: crDataAtom, atomNs: name.ns, atomDef: name.symbolVal)
 
 proc loadCoreSyntax*(programData: var Table[string, ProgramFile], interpret: FnInterpret) =
-  programData[coreNs].defs["assert"] = CirruData(kind: crDataSyntax, syntaxVal: nativeAssert)
   programData[coreNs].defs["quote-replace"] = CirruData(kind: crDataSyntax, syntaxVal: nativeQuoteReplace)
   programData[coreNs].defs["defmacro"] = CirruData(kind: crDataSyntax, syntaxVal: nativeDefMacro)
   programData[coreNs].defs[";"] = CirruData(kind: crDataSyntax, syntaxVal: nativeComment)

--- a/src/calcit_runner/evaluate.nim
+++ b/src/calcit_runner/evaluate.nim
@@ -288,7 +288,7 @@ proc preprocess(code: CirruData, localDefs: Hashset[string], ns: string): CirruD
           return processDefn(code, localDefs, preprocessHelper, ns)
         of "&let":
           return processNativeLet(code, localDefs, preprocessHelper, ns)
-        of "[]", "if", "assert", "do", "quote-replace":
+        of "if", "assert", "do", "quote-replace":
           return processAll(code, localDefs, preprocessHelper, ns)
         of "quote":
           return processQuote(code, localDefs, preprocessHelper, ns)

--- a/src/calcit_runner/types.nim
+++ b/src/calcit_runner/types.nim
@@ -122,22 +122,22 @@ const coreNs* = "calcit.core"
 
 # formatting for CirruData
 
-proc toString*(val: CirruData, details: bool = false): string
+proc toString*(val: CirruData, stringDetail: bool, symbolDetail: bool): string
 
-proc fromListToString(children: seq[CirruData]): string =
-  return "(" & children.mapIt(toString(it, true)).join(" ") & ")"
+proc fromListToString(children: seq[CirruData], symbolDetail: bool): string =
+  return "(" & children.mapIt(toString(it, true, symbolDetail)).join(" ") & ")"
 
-proc fromSetToString(children: HashSet[CirruData]): string =
-  return "#{" & children.mapIt(toString(it, true)).join(" ") & "}"
+proc fromSetToString(children: HashSet[CirruData], symbolDetail: bool): string =
+  return "#{" & children.mapIt(toString(it, true, symbolDetail)).join(" ") & "}"
 
-proc fromMapToString(children: TernaryTreeMap[CirruData, CirruData]): string =
+proc fromMapToString(children: TernaryTreeMap[CirruData, CirruData], symbolDetail: bool): string =
   let size = children.len()
   if size > 100:
     return "{...(100)...}"
   var tableStr = "{"
   var counted = 0
   for k, child in pairs(children):
-    tableStr = tableStr & toString(k, true) & " " & toString(child, true)
+    tableStr = tableStr & toString(k, true, symbolDetail) & " " & toString(child, true, symbolDetail)
     counted = counted + 1
     if counted < children.len:
       tableStr = tableStr & ", "
@@ -151,7 +151,7 @@ proc toString*(children: CirruDataScope): string =
   var tableStr = "{"
   var counted = 0
   for k, child in pairs(children):
-    tableStr = tableStr & k & " " & toString(child)
+    tableStr = tableStr & k & " " & $child
     counted = counted + 1
     if counted < children.len:
       tableStr = tableStr & ", "
@@ -167,7 +167,7 @@ proc escapeString(x: string): string =
   else:
     "|" & x
 
-proc toString*(val: CirruData, details: bool = false): string =
+proc toString*(val: CirruData, stringDetail: bool, symbolDetail: bool): string =
   case val.kind:
     of crDataBool:
       if val.boolVal:
@@ -180,13 +180,13 @@ proc toString*(val: CirruData, details: bool = false): string =
       else:
         $(val.numberVal)
     of crDataString:
-      if details:
+      if stringDetail:
         val.stringVal.escapeString
       else:
         val.stringVal
-    of crDataList: fromListToString(val.listVal.toSeq)
-    of crDataSet: fromSetToString(val.setVal)
-    of crDataMap: fromMapToString(val.mapVal)
+    of crDataList: fromListToString(val.listVal.toSeq, symbolDetail)
+    of crDataSet: fromSetToString(val.setVal, symbolDetail)
+    of crDataMap: fromMapToString(val.mapVal, symbolDetail)
     of crDataNil: "nil"
     of crDataKeyword: ":" & val.keywordVal[]
     of crDataProc: "<Proc>"
@@ -196,10 +196,10 @@ proc toString*(val: CirruData, details: bool = false): string =
       "<Macro: " & val.macroName & " " & $val.macroArgs.toSeq & " " & $val.macroCode & ">"
     of crDataSyntax: "<Syntax>"
     of crDataRecur:
-      let content = val.recurArgs.mapIt(it.toString).join(" ")
+      let content = val.recurArgs.mapIt(it.toString(stringDetail, symbolDetail)).join(" ")
       fmt"<Recur: {content}>"
     of crDataSymbol:
-      if details:
+      if symbolDetail:
         val.ns & "/" & escapeString(val.symbolVal)
       else:
         val.symbolVal
@@ -207,7 +207,7 @@ proc toString*(val: CirruData, details: bool = false): string =
       "<Atom " & val.atomNs & "/" & val.atomDef & " >"
 
 proc `$`*(v: CirruData): string =
-  v.toString(false)
+  v.toString(false, false)
 
 # mutual recursion
 proc hash*(value: CirruData): Hash

--- a/tests/prof.nim
+++ b/tests/prof.nim
@@ -5,7 +5,7 @@ import calcit_runner
 
 let t1 = now()
 
-main()
+discard runProgram("tests/snapshots/fibo.cirru")
 
 let t2 = now()
 

--- a/tests/snapshots/test-map.cirru
+++ b/tests/snapshots/test-map.cirru
@@ -72,7 +72,7 @@
           defn test-native-map-syntax ()
             assert "|internally {} is a macro" $ =
               macroexpand $ quote $ {} (:a 1)
-              quote $ &{} ([] :a 1)
+              quote $ &{} (&[] :a 1)
 
         |log-title $ quote
           defn log-title (title)

--- a/tests/snapshots/test-recursion.cirru
+++ b/tests/snapshots/test-recursion.cirru
@@ -41,12 +41,12 @@
 
         |test-loop $ quote
           fn ()
-            echo $ apply
+            assert= 55 $ apply
               defn add-range (acc from to)
                 if (> from to) acc
                   recur (&+ acc from) (inc from) to
               [] 0 1 10
-            echo $ loop
+            assert= 55 $ loop
                 acc 0
                 from 1
                 to 10


### PR DESCRIPTION
`[]` is moved from syntax to macro, with a helper function `&[]`.
`raise-at` is removed. Now `assert` is a core function. Rich message of assertion should be implemented with macros.