### PR TITLE
optimizing macro implementation for case

### DIFF
--- a/src/calcit_runner/core_func.nim
+++ b/src/calcit_runner/core_func.nim
@@ -984,7 +984,7 @@ proc nativeSetTraceFnBang(args: seq[CirruData], interpret: FnInterpret, scope: C
 proc nativeList(args: seq[CirruData], interpret: FnInterpret, scope: CirruDataScope, ns: string): CirruData =
   CirruData(kind: crDataList, listVal: initTernaryTreeList(args))
 
-proc nativeGenSym(args: seq[CirruData], interpret: FnInterpret, scope: CirruDataScope, ns: string): CirruData =
+proc nativeGensym(args: seq[CirruData], interpret: FnInterpret, scope: CirruDataScope, ns: string): CirruData =
   genSymIndex = genSymIndex + 1
   case args.len
   of 0:
@@ -993,13 +993,18 @@ proc nativeGenSym(args: seq[CirruData], interpret: FnInterpret, scope: CirruData
     let item = args[0]
     case item.kind
     of crDataSymbol:
-      return CirruData(kind: crDataSymbol, ns: ns, dynamic: false, symbolVal: item.symbolVal & "__" & $genSymIndex & "__auto__")
+      return CirruData(kind: crDataSymbol, ns: ns, dynamic: false, symbolVal: item.symbolVal & "__" & $genSymIndex)
     of crDataString:
-      return CirruData(kind: crDataSymbol, ns: ns, dynamic: false, symbolVal: item.stringVal & "__" & $genSymIndex & "__auto__")
+      return CirruData(kind: crDataSymbol, ns: ns, dynamic: false, symbolVal: item.stringVal & "__" & $genSymIndex)
     else:
       raiseEvalError("gensym expects a symbol or a string", args)
   else:
     raiseEvalError("gensym expects 0~1 argument", args)
+
+# TODO this should only be used for testing macros internally
+proc nativeResetGensymIndexBang(args: seq[CirruData], interpret: FnInterpret, scope: CirruDataScope, ns: string): CirruData =
+  genSymIndex = 0
+  CirruData(kind: crDataNil)
 
 # injecting functions to calcit.core directly
 proc loadCoreDefs*(programData: var Table[string, ProgramFile], interpret: FnInterpret): void =
@@ -1084,4 +1089,5 @@ proc loadCoreDefs*(programData: var Table[string, ProgramFile], interpret: FnInt
   programData[coreNs].defs["trim"] = CirruData(kind: crDataProc, procVal: nativeTrim)
   programData[coreNs].defs["set-trace-fn!"] = CirruData(kind: crDataProc, procVal: nativeSetTraceFnBang)
   programData[coreNs].defs["[]"] = CirruData(kind: crDataProc, procVal: nativeList)
-  programData[coreNs].defs["gensym"] = CirruData(kind: crDataProc, procVal: nativeGenSym)
+  programData[coreNs].defs["gensym"] = CirruData(kind: crDataProc, procVal: nativeGensym)
+  programData[coreNs].defs["&reset-gensym-index!"] = CirruData(kind: crDataProc, procVal: nativeResetGensymIndexBang)

--- a/tests/snapshots/test-macro.cirru
+++ b/tests/snapshots/test-macro.cirru
@@ -116,6 +116,8 @@
               macroexpand-all $ quote $ \ + x % %2
               quote $ defn f% (% %2) (+ x % %2)
 
+            &reset-gensym-index!
+
             assert=
               macroexpand-all $ quote
                 case (+ 1 2)
@@ -123,9 +125,10 @@
                   2 |two
                   3 |three
               quote
-                if (&= (+ 1 2) 1) |one
-                  if (&= (+ 1 2) 2) |two
-                    if (&= (+ 1 2) 3) |three nil
+                &let (v__1 (+ 1 2))
+                  if (&= v__1 1) |one
+                    if (&= v__1 2) |two
+                      if (&= v__1 3) |three nil
             assert=
               macroexpand $ quote
                 case (+ 1 2)
@@ -133,8 +136,20 @@
                   2 |two
                   3 |three
               quote
-                if (&= (+ 1 2) 1) |one
-                  case (+ 1 2)
+                &let (v__2 (+ 1 2))
+                  &case v__2
+                    1 |one
+                    2 |two
+                    3 |three
+            assert=
+              macroexpand $ quote
+                &case v__2
+                  1 |one
+                  2 |two
+                  3 |three
+              quote
+                if (&= v__2 1) |one
+                  &case v__2
                     2 |two
                     3 |three
 
@@ -148,9 +163,14 @@
 
         |test-gensym $ quote
           fn ()
-            echo $ gensym
-            echo $ gensym 'a
-            echo $ gensym |a
+            &reset-gensym-index!
+            assert= (gensym) 'G__1
+            assert=
+              gensym 'a
+              , 'a__2
+            assert=
+              gensym |a
+              , 'a__3
 
         |main! $ quote
           defn main! ()

--- a/tests/test_expr.nim
+++ b/tests/test_expr.nim
@@ -2,7 +2,7 @@
 import options
 import unittest
 
-import calcit_runner
+import ./calcit_runner
 
 test "Basic add":
   check (runProgram("tests/snapshots/add.cirru") == crData(3))


### PR DESCRIPTION
added `&case` for reducing redundant evaluation in `case`.
added `&reset-gensym-index!` for debug testing.
refined some issues related to `eval`.
