### PR TITLE
a naive way of modules loading

### DIFF
--- a/src/calcit_runner/evaluate.nim
+++ b/src/calcit_runner/evaluate.nim
@@ -176,6 +176,8 @@ proc preprocessSymbolByPath*(ns: string, def: string): void =
     programData[ns] = newFile
 
   if not programData[ns].defs.hasKey(def):
+    if programCode.hasKey(ns).not:
+      raise newException(ValueError, "No code for such ns: " & ns)
     if programCode[ns].defs.hasKey(def).not:
       raise newException(ValueError, "No such definition: " & def)
     var code = programCode[ns].defs[def]

--- a/src/calcit_runner/loader.nim
+++ b/src/calcit_runner/loader.nim
@@ -70,6 +70,17 @@ proc getCodeConfigs(initialData: CirruEdnValue): CodeConfigs =
   let package = initialData.get(crEdn("package", true))
   if package.kind != crEdnString:
     raise newException(ValueError, "expects a string")
+
+  if configs.contains(crEdn("modules", true)):
+    let modulesList = configs.get(crEdn("modules", true))
+    if modulesList.kind != crEdnVector:
+      raise newException(ValueError, "expects a vector")
+
+    for item in modulesList.vectorVal:
+      if item.kind != crEdnString:
+        raise newException(ValueError, "expects string")
+      codeConfigs.modules.add item.stringVal
+
   codeConfigs.pkg = package.stringVal
 
   return codeConfigs

--- a/src/calcit_runner/types.nim
+++ b/src/calcit_runner/types.nim
@@ -111,6 +111,7 @@ type CodeConfigs* = object
   pkg*: string
   initFn*: string
   reloadFn*: string
+  modules*: seq[string]
 
 type FileSource* = object
   ns*: CirruData


### PR DESCRIPTION
With current implementation, one has to add `:modules ["full-path-to-compact-file.cirru"]` in `calcit.cirru` and regenerate `compact.cirru`. `cr` command will load all modules, but it won't handle dependencies, which means recursive ones are ignored.
