### PR TITLE
use a restricted module path

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ cr -e="echo $ range 100" # eval from CLI
 
 _Not ready for a release yet_
 
+
+### Modules
+
+```cirru
+:configs $ {}
+  :modules $ [] |phlox.caclit.nim/compact.cirru
+```
+
+Calcit Runner use `~/.config/calcit/modules/` as modules directory.
+Paths defined in `:modules` field are just loaded as files based on this directory,
+which is: `~/.config/calcit/modules/phlox.caclit.nim/compact.cirru`.
+
 ### License
 
 MIT

--- a/src/calcit_runner.nim
+++ b/src/calcit_runner.nim
@@ -91,8 +91,9 @@ proc runCode(ns: string, def: string, argData: CirruData, dropArg: bool = false)
 
 # only load code of modules, ignore recursive deps
 proc loadModules(modulePath: string) =
-  echo "Loading modules from path: ", modulePath
-  let snapshotInfo = loadSnapshot(modulePath)
+  let fullpath = getEnv("HOME").joinPath(".config/calcit/modules/", modulePath)
+  echo "Loading modules from path: ", fullpath
+  let snapshotInfo = loadSnapshot(fullpath)
 
   for fileNs, file in snapshotInfo.files:
     programCode[fileNs] = file


### PR DESCRIPTION
if module can be loaded from any path, a user may use local repository for convenience. that's not good for maintenance. in current solution, modules are stored in `~/.config/calcit/modules`, with no restriction of file structure. `cr` command just loads a `compact.cirru` file inside module directory. Personally I use git to maintain modules, with no package versions.

One can also added a CLI too for downloading files via Git and maintain directories. I'm not ready yet.
